### PR TITLE
fix: implement PraxisMemory module with cutoff context

### DIFF
--- a/idea/Plan/Architecture/MemoryModel.md
+++ b/idea/Plan/Architecture/MemoryModel.md
@@ -12,6 +12,8 @@
 
 ## 1. Class contract
 
+Status: shipped in `praxis_env/memory.py` (Issue #3).
+
 ```python
 # praxis_env/memory.py
 from dataclasses import dataclass, field
@@ -70,6 +72,8 @@ sequenceDiagram
 ---
 
 ## 3. Cutoff behaviour (the differentiator)
+
+Status: shipped in `praxis_env/memory.py::PraxisMemory.get_observation_context` (Issue #3).
 
 ```python
 def get_observation_context(self, full_log: list[str], step: int) -> str:

--- a/idea/Plan/Project/DecisionLog.md
+++ b/idea/Plan/Project/DecisionLog.md
@@ -64,6 +64,8 @@ Add `save_finding` and `recall_memory` as agent-callable commands. After step 30
 
 This is the **moat**. The frontier paper (S29) says passive summarisation by the framework fails because the agent never had a chance to express what it considered important. AgeMem (S28) shows GRPO trains naturally on memory-as-tool. Praxis ships exactly this.
 
+Implementation cross-link: `praxis_env/memory.py` (Issue #3). Cutoff behavior details live in [`MemoryModel.md`](../Architecture/MemoryModel.md) §3.
+
 Alternatives considered:
 
 - **SUPO-style automatic summarisation (S22)** — rejected: same failure mode as S29; also would dilute the moat ("nobody else has memory-as-tool").

--- a/praxis_env/__init__.py
+++ b/praxis_env/__init__.py
@@ -9,12 +9,14 @@ Example usage:
 
 from praxis_env.models import PraxisAction, PraxisObservation, PraxisState
 from praxis_env.client import PraxisEnv
+from praxis_env.memory import PraxisMemory
 
 __all__ = [
     "PraxisAction",
     "PraxisObservation",
     "PraxisState",
     "PraxisEnv",
+    "PraxisMemory",
 ]
 
 __version__ = "1.0.0"

--- a/praxis_env/memory.py
+++ b/praxis_env/memory.py
@@ -31,7 +31,10 @@ class PraxisMemory:
         if not self.saved_findings:
             return "No findings saved."
 
-        lines = [f"{saved_key}: {self.saved_findings[saved_key]}" for saved_key in sorted(self.saved_findings)]
+        lines = [
+            f"{saved_key}: {self.saved_findings[saved_key]}"
+            for saved_key in sorted(self.saved_findings)
+        ]
         return "\n".join(lines)
 
     def get_observation_context(self, full_log: list[str], step: int) -> str:

--- a/praxis_env/memory.py
+++ b/praxis_env/memory.py
@@ -1,0 +1,61 @@
+"""
+praxis_env.memory - Agent-controlled working memory.
+
+# Grounded in arxiv AgeMem (S28) + arxiv 2601.07190 Context Bloat (S29)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class PraxisMemory:
+    """Pure, deterministic memory state machine scoped to one episode."""
+
+    saved_findings: dict[str, str] = field(default_factory=dict)
+    CONTEXT_CUTOFF_STEP: int = 30
+
+    def save_finding(self, key: str, value: str) -> str:
+        """Persist or overwrite a finding and return a stable acknowledgement."""
+        self.saved_findings[str(key)] = str(value)
+        return f"Saved: {key}"
+
+    def recall_memory(self, key: str | None = None) -> str:
+        """Recall one finding by key, or all saved findings if key is omitted."""
+        if key is not None:
+            if key in self.saved_findings:
+                return self.saved_findings[key]
+            return f"No saved finding for key: {key}"
+
+        if not self.saved_findings:
+            return "No findings saved."
+
+        lines = [f"{saved_key}: {self.saved_findings[saved_key]}" for saved_key in sorted(self.saved_findings)]
+        return "\n".join(lines)
+
+    def get_observation_context(self, full_log: list[str], step: int) -> str:
+        """
+        Return visible investigation context based on cutoff state.
+
+        Before cutoff: return the last 10 entries of the raw log.
+        After cutoff: return the deterministic memory-only banner.
+        """
+        if step < self.CONTEXT_CUTOFF_STEP:
+            return "\n".join(full_log[-10:]) if full_log else ""
+
+        return (
+            f"[CONTEXT LIMIT REACHED — Step {step}/{self.CONTEXT_CUTOFF_STEP}]\n"
+            "Full investigation log is no longer available.\n"
+            f"Your saved findings:\n{self.recall_memory()}\n\n"
+            "Use recall_memory to retrieve specific findings.\n"
+            "Use save_finding to persist new evidence."
+        )
+
+    def is_active(self, step: int) -> bool:
+        """Return whether memory cutoff mode is active at this step."""
+        return step >= self.CONTEXT_CUTOFF_STEP
+
+    def reset(self) -> None:
+        """Clear all saved findings for a new episode."""
+        self.saved_findings.clear()

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -8,12 +8,19 @@ If this fails, the environment will NEVER pass openenv validate.
 
 def test_import_praxis_env_package():
     """The public API must be importable."""
-    from praxis_env import PraxisAction, PraxisObservation, PraxisState, PraxisEnv
+    from praxis_env import (
+        PraxisAction,
+        PraxisEnv,
+        PraxisMemory,
+        PraxisObservation,
+        PraxisState,
+    )
 
     assert PraxisAction is not None
     assert PraxisObservation is not None
     assert PraxisState is not None
     assert PraxisEnv is not None
+    assert PraxisMemory is not None
 
 
 def test_import_models_directly():

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,79 @@
+"""
+tests/test_memory.py - Unit tests for PraxisMemory.
+"""
+
+from praxis_env.memory import PraxisMemory
+
+
+def test_save_finding_returns_confirmation_and_persists():
+    memory = PraxisMemory()
+    response = memory.save_finding("db_pool", "exhausted")
+
+    assert response == "Saved: db_pool"
+    assert memory.saved_findings["db_pool"] == "exhausted"
+
+
+def test_recall_specific_key():
+    memory = PraxisMemory(saved_findings={"root_cause": "bad_config"})
+    assert memory.recall_memory("root_cause") == "bad_config"
+
+
+def test_recall_unknown_key_returns_helpful_message():
+    memory = PraxisMemory(saved_findings={"root_cause": "bad_config"})
+    assert memory.recall_memory("missing_key") == "No saved finding for key: missing_key"
+
+
+def test_recall_all_returns_deterministic_sorted_lines():
+    memory = PraxisMemory(saved_findings={"b": "value_b", "a": "value_a"})
+    assert memory.recall_memory() == "a: value_a\nb: value_b"
+
+
+def test_recall_all_when_empty():
+    memory = PraxisMemory()
+    assert memory.recall_memory() == "No findings saved."
+
+
+def test_get_observation_context_pre_cutoff_returns_last_ten_entries():
+    memory = PraxisMemory(CONTEXT_CUTOFF_STEP=30)
+    full_log = [f"log_{i}" for i in range(15)]
+
+    context = memory.get_observation_context(full_log=full_log, step=29)
+
+    assert context == "\n".join(full_log[-10:])
+
+
+def test_get_observation_context_post_cutoff_returns_banner_and_findings():
+    memory = PraxisMemory(saved_findings={"db_pool": "exhausted"}, CONTEXT_CUTOFF_STEP=30)
+
+    context = memory.get_observation_context(full_log=["ignored"], step=30)
+
+    assert "[CONTEXT LIMIT REACHED — Step 30/30]" in context
+    assert "Full investigation log is no longer available." in context
+    assert "Your saved findings:" in context
+    assert "db_pool: exhausted" in context
+    assert "Use recall_memory to retrieve specific findings." in context
+    assert "Use save_finding to persist new evidence." in context
+
+
+def test_is_active_matches_cutoff_rule():
+    memory = PraxisMemory(CONTEXT_CUTOFF_STEP=30)
+    assert memory.is_active(29) is False
+    assert memory.is_active(30) is True
+    assert memory.is_active(31) is True
+
+
+def test_reset_clears_saved_findings():
+    memory = PraxisMemory(saved_findings={"k": "v"})
+    memory.reset()
+    assert memory.saved_findings == {}
+
+
+def test_determinism_same_inputs_same_output_bytes():
+    memory = PraxisMemory(saved_findings={"alpha": "1", "beta": "2"}, CONTEXT_CUTOFF_STEP=30)
+    full_log = [f"log_{i}" for i in range(20)]
+
+    output_1 = memory.get_observation_context(full_log=full_log, step=35)
+    output_2 = memory.get_observation_context(full_log=full_log, step=35)
+
+    assert output_1 == output_2
+    assert output_1.encode("utf-8") == output_2.encode("utf-8")

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -20,7 +20,9 @@ def test_recall_specific_key():
 
 def test_recall_unknown_key_returns_helpful_message():
     memory = PraxisMemory(saved_findings={"root_cause": "bad_config"})
-    assert memory.recall_memory("missing_key") == "No saved finding for key: missing_key"
+    assert (
+        memory.recall_memory("missing_key") == "No saved finding for key: missing_key"
+    )
 
 
 def test_recall_all_returns_deterministic_sorted_lines():
@@ -43,7 +45,9 @@ def test_get_observation_context_pre_cutoff_returns_last_ten_entries():
 
 
 def test_get_observation_context_post_cutoff_returns_banner_and_findings():
-    memory = PraxisMemory(saved_findings={"db_pool": "exhausted"}, CONTEXT_CUTOFF_STEP=30)
+    memory = PraxisMemory(
+        saved_findings={"db_pool": "exhausted"}, CONTEXT_CUTOFF_STEP=30
+    )
 
     context = memory.get_observation_context(full_log=["ignored"], step=30)
 
@@ -69,7 +73,9 @@ def test_reset_clears_saved_findings():
 
 
 def test_determinism_same_inputs_same_output_bytes():
-    memory = PraxisMemory(saved_findings={"alpha": "1", "beta": "2"}, CONTEXT_CUTOFF_STEP=30)
+    memory = PraxisMemory(
+        saved_findings={"alpha": "1", "beta": "2"}, CONTEXT_CUTOFF_STEP=30
+    )
     full_log = [f"log_{i}" for i in range(20)]
 
     output_1 = memory.get_observation_context(full_log=full_log, step=35)


### PR DESCRIPTION
- Fixes #3

## Root cause
The repository did not yet implement the explicit `PraxisMemory` state machine described in the memory architecture spec, so there was no deterministic agent-controlled storage API and no cutoff context renderer at step 30.

## What changed and why
- Added `praxis_env/memory.py` with `PraxisMemory` dataclass and required methods: `save_finding`, `recall_memory`, `get_observation_context`, `is_active`, `reset`.
- Implemented cutoff behavior from `idea/Plan/Architecture/MemoryModel.md` section 3: pre-cutoff returns last 10 log lines; post-cutoff returns the context-limit banner plus saved findings.
- Exported `PraxisMemory` from `praxis_env/__init__.py` to make it part of the package public API.
- Added `tests/test_memory.py` to lock deterministic behavior, save/recall/reset, cutoff transitions, and output stability.
- Updated `tests/test_imports.py` so public API import coverage includes `PraxisMemory`.
- Updated plan docs requested in the issue:
  - `idea/Plan/Architecture/MemoryModel.md` (section 1 and section 3 marked shipped)
  - `idea/Plan/Project/DecisionLog.md` (ADR-05 implementation cross-link)

## How to test
- `.\\.venv\\Scripts\\python.exe -m pytest -q tests/test_memory.py tests/test_imports.py`
- `.\\.venv\\Scripts\\python.exe -m pytest -q tests/test_models.py`

## Assumption
Issue #3 references `Architecture/MemoryModel.md` and `Project/DecisionLog.md`; in this repo those canonical files are located under `idea/Plan/Architecture/MemoryModel.md` and `idea/Plan/Project/DecisionLog.md`, so those were updated.