### PR TITLE
fix: add cutoff-aware memory rewards across task policies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: local
+    hooks:
+      - id: ruff-format
+        name: ruff format
+        entry: uv run ruff format
+        language: system
+        files: ^(praxis_env/|server/|tests/|inference\.py)
+      - id: ruff-check
+        name: ruff check
+        entry: uv run ruff check
+        language: system
+        files: ^(praxis_env/|server/|tests/|inference\.py)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -9,6 +9,7 @@ documentation cleanup all help.
 
 ```bash
 pip install -e ".[dev]"
+pre-commit install
 ```
 
 ---
@@ -124,6 +125,7 @@ class YourScenario(BaseScenario):
   derive that list from the current status map.
 - Do not mutate `_step_count` or `_cumulative_reward` inside scenario code.
 - Keep scenario text ASCII-friendly when practical.
+- Run `pre-commit run --all-files` before pushing.
 
 ---
 

--- a/idea/Plan/Architecture/MemoryModel.md
+++ b/idea/Plan/Architecture/MemoryModel.md
@@ -105,8 +105,11 @@ Memory events emit reward tags that every task policy maps to a number:
 | `memory.recall_memory.before_cutoff` | +0.01         | Tiny — discourages habitual recall.         |
 | `memory.recall_memory.after_cutoff`  | +0.08         | Strong: planning paid off.                  |
 | `memory.illegal_log_after_cutoff`    | −0.05         | Querying logs after cutoff (logs are gone). |
+| `memory.empty_recall_after_cutoff`   | −0.02         | Recall after cutoff with no saved findings. |
 
-These are added to **every task's** `event_values` so the memory tools work for all 6 scenarios. See [`RewardPolicy.md`](./RewardPolicy.md) for full per-task tables.
+These are added to **every task's** `event_values` so the memory tools work for all scenarios. See [`RewardPolicy.md`](./RewardPolicy.md) for full per-task tables.
+
+Cross-link: ADR-13 additionally enforces an evidence gate where `remediation.*` scores are zeroed until root-cause diagnosis is confirmed, preventing memory-assisted reward hacking before diagnosis.
 
 ---
 

--- a/idea/Plan/Architecture/RewardPolicy.md
+++ b/idea/Plan/Architecture/RewardPolicy.md
@@ -202,6 +202,7 @@ def _with_memory_events(events: Mapping[str, float]) -> Mapping[str, float]:
 
 - `RewardEngine.score()` returns a `RewardResult(reward, breakdown)` where `reward = clamp(sum(components), 0.01, 0.99)`.
 - Memory bonuses are added in the `investigation_reward` slot (positive) or `redundancy_penalty` slot (negative); they do **not** double-clamp before the final sum.
+- Per ADR-13, any `remediation.*` event is forced to zero pre-clamp when `root_cause_identified=False` so remediation cannot score before diagnosis.
 - Issue #5 acceptance criteria require: the test suite proves no policy exceeds `[0.01, 0.99]` over 1000 random sequences.
 
 ---
@@ -212,4 +213,5 @@ def _with_memory_events(events: Mapping[str, float]) -> Mapping[str, float]:
 - [ ] No event value is outside `[-0.20, +0.30]` pre-clamp (sanity bound).
 - [ ] `time_pressure_cost_per_step` is set per task as in §2/§3.
 - [ ] `clamp_reward` is applied exactly once at the boundary.
+- [ ] `remediation.*` events are zeroed when `root_cause_identified=False` (ADR-13 evidence gate).
 - [ ] `pytest -q tests/test_reward.py` and `tests/test_memory.py` pass.

--- a/idea/Plan/Project/DecisionLog.md
+++ b/idea/Plan/Project/DecisionLog.md
@@ -157,6 +157,7 @@ Why now: with sparse rewards added in this hackathon push, "diagnose-before-reme
 Implementation:
 
 - `server/reward.py` (Issue #5): `RewardEngine.score(...)` checks `event.startswith("remediation.")` and returns `RewardResult(reward=clamp_reward(0.0), ...)` when `root_cause_identified=False`. New unit test row per task in `tests/test_reward.py::test_remediation_requires_diagnosis`.
+- `tests/test_reward.py` (Issue #5): verifies all default policies include the 6 cross-task memory event tags and includes a 1000-sequence clamp sweep to keep scores within `[0.01, 0.99]`.
 - `MegaIncidentScenario.step` (Issue #7) and `ProceduralIncidentScenario.step` (Issue #8): same guard in the scenario layer for defense-in-depth.
 - Tests (Issue #14): `test_remediation_before_diagnosis_scores_zero` runs against both new scenarios + 3 procedural difficulties.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dev = [
     "httpx",
     "ruff",
     "mypy",
+    "pre-commit",
 ]
 
 [tool.setuptools.packages.find]

--- a/server/reward.py
+++ b/server/reward.py
@@ -87,6 +87,23 @@ class RewardPolicy:
     time_pressure_cost_per_step: float = 0.0
 
 
+_MEMORY_EVENTS: Mapping[str, float] = {
+    "memory.save_finding.before_cutoff": 0.05,
+    "memory.save_finding.after_cutoff": 0.02,
+    "memory.recall_memory.before_cutoff": 0.01,
+    "memory.recall_memory.after_cutoff": 0.08,
+    "memory.illegal_log_after_cutoff": -0.05,
+    "memory.empty_recall_after_cutoff": -0.02,
+}
+
+
+def _with_memory_events(events: Mapping[str, float]) -> dict[str, float]:
+    """Return a new event-value mapping with cross-task memory event rows."""
+    merged = dict(events)
+    merged.update(_MEMORY_EVENTS)
+    return merged
+
+
 # ── Reward Calibration ──────────────────────────────────────────────────────
 #
 # Each value is chosen to produce a target difficulty curve:
@@ -111,7 +128,7 @@ DEFAULT_REWARD_POLICIES: dict[str, RewardPolicy] = {
     # Generous investigation rewards so partial investigation is well-rewarded.
     # No step cost — the easy task is forgiving by design.
     "single-service-alert": RewardPolicy(
-        event_values={
+        event_values=_with_memory_events({
             # Investigation — generous for the easy task
             "investigation.query_logs.auth": 0.08,  # key service
             "investigation.query_logs.default": 0.05,  # exploring is okay
@@ -133,7 +150,7 @@ DEFAULT_REWARD_POLICIES: dict[str, RewardPolicy] = {
             # Error handling
             "unknown_command": 0.0,
             "invalid_input": 0.0,
-        },
+        }),
         # Easy task: no step cost, mild penalties
         time_pressure_cost_per_step=0.0,
     ),
@@ -142,7 +159,7 @@ DEFAULT_REWARD_POLICIES: dict[str, RewardPolicy] = {
     # Investigation rewards are lower — must follow the dependency chain.
     # Stronger step cost penalizes wandering through red herrings.
     "cascading-failure": RewardPolicy(
-        event_values={
+        event_values=_with_memory_events({
             # Investigation — lower rewards, must multi-hop to find root cause
             "investigation.query_logs.api": 0.03,  # symptom service, low value
             "investigation.query_logs.database": 0.05,  # closer to root cause
@@ -169,7 +186,7 @@ DEFAULT_REWARD_POLICIES: dict[str, RewardPolicy] = {
             # Error handling
             "unknown_command": 0.0,
             "invalid_input": 0.0,
-        },
+        }),
         # Hard task: stronger step cost discourages aimless exploration
         time_pressure_cost_per_step=0.006,
     ),
@@ -178,7 +195,7 @@ DEFAULT_REWARD_POLICIES: dict[str, RewardPolicy] = {
     # evidence correlation but with less harsh remediation pressure than
     # the hard tasks.
     "ambiguous-incident": RewardPolicy(
-        event_values={
+        event_values=_with_memory_events({
             # Investigation — must check 3+ app services + infra
             "investigation.query_logs.app": 0.048,
             "investigation.query_logs.dns-resolver": 0.095,
@@ -204,7 +221,7 @@ DEFAULT_REWARD_POLICIES: dict[str, RewardPolicy] = {
             # Error handling
             "unknown_command": 0.0,
             "invalid_input": 0.0,
-        },
+        }),
         # Medium task: mild step cost
         time_pressure_cost_per_step=0.003,
     ),
@@ -212,7 +229,7 @@ DEFAULT_REWARD_POLICIES: dict[str, RewardPolicy] = {
     # Requires checking memory metrics and config to find the OOM cause.
     # Target optimal path: ~0.48 in 5 steps.
     "memory-leak": RewardPolicy(
-        event_values={
+        event_values=_with_memory_events({
             # Investigation
             "investigation.query_logs.worker": 0.04,
             "investigation.query_logs.default": 0.02,
@@ -235,7 +252,7 @@ DEFAULT_REWARD_POLICIES: dict[str, RewardPolicy] = {
             # Error handling
             "unknown_command": 0.0,
             "invalid_input": 0.0,
-        },
+        }),
         time_pressure_cost_per_step=0.005,
     ),
 }
@@ -255,6 +272,7 @@ class RewardEngine:
         duplicate: bool = False,
         premature: bool = False,
         destructive: bool = False,
+        root_cause_identified: bool = True,
         resolved: bool = False,
         step_number: int = 1,
         max_steps: int = 1,
@@ -268,6 +286,7 @@ class RewardEngine:
             duplicate: True if this action repeats already-seen evidence.
             premature: True if action happened before evidence threshold.
             destructive: True for materially harmful wrong remediations.
+            root_cause_identified: Whether root cause was diagnosed already.
             resolved: True when this action resolves or ends the incident.
             step_number: 1-based action index for optional timing bonuses.
             max_steps: Episode step limit.
@@ -280,6 +299,13 @@ class RewardEngine:
                 f"Available policies: [{available}]"
             )
 
+        if event.startswith("remediation.") and not root_cause_identified:
+            breakdown = RewardBreakdown(total_unclamped=0.0)
+            return RewardResult(
+                reward=clamp_reward(breakdown.total_unclamped),
+                breakdown=breakdown,
+            )
+
         event_value = policy.event_values.get(event, 0.0)
         effective_value = 0.0 if duplicate else event_value
 
@@ -290,6 +316,8 @@ class RewardEngine:
         escalation_reward = 0.0
 
         if event.startswith("investigation."):
+            investigation_reward = effective_value
+        elif event.startswith("memory."):
             investigation_reward = effective_value
         elif event == "diagnosis.correct":
             diagnosis_reward = effective_value

--- a/server/reward.py
+++ b/server/reward.py
@@ -128,29 +128,31 @@ DEFAULT_REWARD_POLICIES: dict[str, RewardPolicy] = {
     # Generous investigation rewards so partial investigation is well-rewarded.
     # No step cost — the easy task is forgiving by design.
     "single-service-alert": RewardPolicy(
-        event_values=_with_memory_events({
-            # Investigation — generous for the easy task
-            "investigation.query_logs.auth": 0.08,  # key service
-            "investigation.query_logs.default": 0.05,  # exploring is okay
-            "investigation.check_metrics.connections": 0.08,
-            "investigation.check_metrics.default": 0.05,
-            "investigation.check_deps.default": 0.05,
-            "investigation.check_config.auth": 0.10,  # high-value: reveals the config typo
-            "investigation.check_config.default": 0.03,
-            "investigation.check_runbook.default": 0.05,  # consulting runbook is rewarded
-            # Diagnosis
-            "diagnosis.correct": 0.20,
-            "diagnosis.wrong": 0.0,
-            # Remediation
-            "remediation.rollback_deploy.auth": 0.25,  # correct fix = highest single reward
-            "remediation.wrong": 0.0,
-            # Escalation
-            "escalation.with_evidence": 0.15,
-            "escalation.no_evidence": 0.0,
-            # Error handling
-            "unknown_command": 0.0,
-            "invalid_input": 0.0,
-        }),
+        event_values=_with_memory_events(
+            {
+                # Investigation — generous for the easy task
+                "investigation.query_logs.auth": 0.08,  # key service
+                "investigation.query_logs.default": 0.05,  # exploring is okay
+                "investigation.check_metrics.connections": 0.08,
+                "investigation.check_metrics.default": 0.05,
+                "investigation.check_deps.default": 0.05,
+                "investigation.check_config.auth": 0.10,  # high-value: reveals the config typo
+                "investigation.check_config.default": 0.03,
+                "investigation.check_runbook.default": 0.05,  # consulting runbook is rewarded
+                # Diagnosis
+                "diagnosis.correct": 0.20,
+                "diagnosis.wrong": 0.0,
+                # Remediation
+                "remediation.rollback_deploy.auth": 0.25,  # correct fix = highest single reward
+                "remediation.wrong": 0.0,
+                # Escalation
+                "escalation.with_evidence": 0.15,
+                "escalation.no_evidence": 0.0,
+                # Error handling
+                "unknown_command": 0.0,
+                "invalid_input": 0.0,
+            }
+        ),
         # Easy task: no step cost, mild penalties
         time_pressure_cost_per_step=0.0,
     ),
@@ -159,34 +161,36 @@ DEFAULT_REWARD_POLICIES: dict[str, RewardPolicy] = {
     # Investigation rewards are lower — must follow the dependency chain.
     # Stronger step cost penalizes wandering through red herrings.
     "cascading-failure": RewardPolicy(
-        event_values=_with_memory_events({
-            # Investigation — lower rewards, must multi-hop to find root cause
-            "investigation.query_logs.api": 0.03,  # symptom service, low value
-            "investigation.query_logs.database": 0.05,  # closer to root cause
-            "investigation.query_logs.analytics": 0.05,  # reveals the runaway query
-            "investigation.query_logs.default": 0.02,  # exploring other services
-            "investigation.check_metrics.database.connections": 0.08,  # key metric
-            "investigation.check_metrics.default": 0.02,
-            "investigation.check_deps.core": 0.03,  # reveals db dependency
-            "investigation.check_deps.default": 0.02,
-            "investigation.check_config.database": 0.03,
-            "investigation.check_config.analytics": 0.03,
-            "investigation.check_config.default": 0.02,
-            "investigation.check_runbook.default": 0.03,
-            # Diagnosis — moderate, must earn it through investigation
-            "diagnosis.correct": 0.14,
-            "diagnosis.wrong": 0.0,
-            # Remediation — both needed for full resolution
-            "remediation.kill_query.database": 0.09,  # stop the bleeding
-            "remediation.scale_resource.database.connection_pool": 0.08,  # prevent recurrence
-            "remediation.wrong": 0.0,
-            # Escalation
-            "escalation.with_evidence": 0.09,
-            "escalation.no_evidence": 0.0,
-            # Error handling
-            "unknown_command": 0.0,
-            "invalid_input": 0.0,
-        }),
+        event_values=_with_memory_events(
+            {
+                # Investigation — lower rewards, must multi-hop to find root cause
+                "investigation.query_logs.api": 0.03,  # symptom service, low value
+                "investigation.query_logs.database": 0.05,  # closer to root cause
+                "investigation.query_logs.analytics": 0.05,  # reveals the runaway query
+                "investigation.query_logs.default": 0.02,  # exploring other services
+                "investigation.check_metrics.database.connections": 0.08,  # key metric
+                "investigation.check_metrics.default": 0.02,
+                "investigation.check_deps.core": 0.03,  # reveals db dependency
+                "investigation.check_deps.default": 0.02,
+                "investigation.check_config.database": 0.03,
+                "investigation.check_config.analytics": 0.03,
+                "investigation.check_config.default": 0.02,
+                "investigation.check_runbook.default": 0.03,
+                # Diagnosis — moderate, must earn it through investigation
+                "diagnosis.correct": 0.14,
+                "diagnosis.wrong": 0.0,
+                # Remediation — both needed for full resolution
+                "remediation.kill_query.database": 0.09,  # stop the bleeding
+                "remediation.scale_resource.database.connection_pool": 0.08,  # prevent recurrence
+                "remediation.wrong": 0.0,
+                # Escalation
+                "escalation.with_evidence": 0.09,
+                "escalation.no_evidence": 0.0,
+                # Error handling
+                "unknown_command": 0.0,
+                "invalid_input": 0.0,
+            }
+        ),
         # Hard task: stronger step cost discourages aimless exploration
         time_pressure_cost_per_step=0.006,
     ),
@@ -195,33 +199,35 @@ DEFAULT_REWARD_POLICIES: dict[str, RewardPolicy] = {
     # evidence correlation but with less harsh remediation pressure than
     # the hard tasks.
     "ambiguous-incident": RewardPolicy(
-        event_values=_with_memory_events({
-            # Investigation — must check 3+ app services + infra
-            "investigation.query_logs.app": 0.048,
-            "investigation.query_logs.dns-resolver": 0.095,
-            "investigation.query_logs.default": 0.028,
-            "investigation.check_metrics.dns-resolver.resolution_failures": 0.095,
-            "investigation.check_metrics.app": 0.028,
-            "investigation.check_metrics.load-balancer": 0.018,
-            "investigation.check_metrics.default": 0.018,
-            "investigation.check_deps.default": 0.028,
-            "investigation.check_config.dns-resolver": 0.045,
-            "investigation.check_config.app": 0.018,
-            "investigation.check_config.default": 0.01,
-            "investigation.check_runbook.default": 0.028,
-            # Diagnosis
-            "diagnosis.correct": 0.19,
-            "diagnosis.wrong": 0.0,
-            # Remediation
-            "remediation.restart_service.dns-resolver": 0.14,
-            "remediation.wrong": 0.0,
-            # Escalation
-            "escalation.with_evidence": 0.14,
-            "escalation.no_evidence": 0.0,
-            # Error handling
-            "unknown_command": 0.0,
-            "invalid_input": 0.0,
-        }),
+        event_values=_with_memory_events(
+            {
+                # Investigation — must check 3+ app services + infra
+                "investigation.query_logs.app": 0.048,
+                "investigation.query_logs.dns-resolver": 0.095,
+                "investigation.query_logs.default": 0.028,
+                "investigation.check_metrics.dns-resolver.resolution_failures": 0.095,
+                "investigation.check_metrics.app": 0.028,
+                "investigation.check_metrics.load-balancer": 0.018,
+                "investigation.check_metrics.default": 0.018,
+                "investigation.check_deps.default": 0.028,
+                "investigation.check_config.dns-resolver": 0.045,
+                "investigation.check_config.app": 0.018,
+                "investigation.check_config.default": 0.01,
+                "investigation.check_runbook.default": 0.028,
+                # Diagnosis
+                "diagnosis.correct": 0.19,
+                "diagnosis.wrong": 0.0,
+                # Remediation
+                "remediation.restart_service.dns-resolver": 0.14,
+                "remediation.wrong": 0.0,
+                # Escalation
+                "escalation.with_evidence": 0.14,
+                "escalation.no_evidence": 0.0,
+                # Error handling
+                "unknown_command": 0.0,
+                "invalid_input": 0.0,
+            }
+        ),
         # Medium task: mild step cost
         time_pressure_cost_per_step=0.003,
     ),
@@ -229,30 +235,32 @@ DEFAULT_REWARD_POLICIES: dict[str, RewardPolicy] = {
     # Requires checking memory metrics and config to find the OOM cause.
     # Target optimal path: ~0.48 in 5 steps.
     "memory-leak": RewardPolicy(
-        event_values=_with_memory_events({
-            # Investigation
-            "investigation.query_logs.worker": 0.04,
-            "investigation.query_logs.default": 0.02,
-            "investigation.check_metrics.worker.memory": 0.09,
-            "investigation.check_metrics.default": 0.02,
-            "investigation.check_deps.default": 0.02,
-            "investigation.check_config.worker": 0.04,
-            "investigation.check_config.default": 0.02,
-            "investigation.check_runbook.default": 0.03,
-            # Diagnosis
-            "diagnosis.correct": 0.14,
-            "diagnosis.wrong": 0.0,
-            # Remediation
-            "remediation.rollback_deploy.worker": 0.19,
-            "remediation.scale_resource.worker.memory": 0.19,
-            "remediation.wrong": 0.0,
-            # Escalation
-            "escalation.with_evidence": 0.10,
-            "escalation.no_evidence": 0.0,
-            # Error handling
-            "unknown_command": 0.0,
-            "invalid_input": 0.0,
-        }),
+        event_values=_with_memory_events(
+            {
+                # Investigation
+                "investigation.query_logs.worker": 0.04,
+                "investigation.query_logs.default": 0.02,
+                "investigation.check_metrics.worker.memory": 0.09,
+                "investigation.check_metrics.default": 0.02,
+                "investigation.check_deps.default": 0.02,
+                "investigation.check_config.worker": 0.04,
+                "investigation.check_config.default": 0.02,
+                "investigation.check_runbook.default": 0.03,
+                # Diagnosis
+                "diagnosis.correct": 0.14,
+                "diagnosis.wrong": 0.0,
+                # Remediation
+                "remediation.rollback_deploy.worker": 0.19,
+                "remediation.scale_resource.worker.memory": 0.19,
+                "remediation.wrong": 0.0,
+                # Escalation
+                "escalation.with_evidence": 0.10,
+                "escalation.no_evidence": 0.0,
+                # Error handling
+                "unknown_command": 0.0,
+                "invalid_input": 0.0,
+            }
+        ),
         time_pressure_cost_per_step=0.005,
     ),
 }

--- a/tests/test_reward.py
+++ b/tests/test_reward.py
@@ -5,9 +5,17 @@ These tests validate centralized reward scoring semantics independently from
 scenario business logic.
 """
 
+import random
+
 import pytest
 
-from server.reward import RewardEngine, RewardPolicy, clamp_reward
+from server.reward import (
+    DEFAULT_REWARD_POLICIES,
+    _MEMORY_EVENTS,
+    RewardEngine,
+    RewardPolicy,
+    clamp_reward,
+)
 
 
 def test_clamp_reward_bounds():
@@ -121,3 +129,53 @@ def test_clamp_upper_bound_with_large_event_reward():
     result = engine.score(task_name="custom", event="diagnosis.correct")
     assert result.reward == pytest.approx(0.99)
     assert result.breakdown.total_unclamped == pytest.approx(1.25)
+
+
+def test_all_default_policies_include_memory_event_rows():
+    expected_keys = set(_MEMORY_EVENTS.keys())
+    for task_name, policy in DEFAULT_REWARD_POLICIES.items():
+        assert expected_keys.issubset(policy.event_values.keys()), task_name
+
+
+def test_memory_recall_after_cutoff_value_is_used_pre_clamp():
+    engine = RewardEngine()
+    result = engine.score(
+        task_name="single-service-alert",
+        event="memory.recall_memory.after_cutoff",
+    )
+    assert result.breakdown.total_unclamped == pytest.approx(0.08)
+    assert result.reward == pytest.approx(0.08)
+
+
+@pytest.mark.parametrize("task_name", sorted(DEFAULT_REWARD_POLICIES.keys()))
+def test_remediation_requires_diagnosis(task_name: str):
+    engine = RewardEngine()
+    result = engine.score(
+        task_name=task_name,
+        event="remediation.wrong",
+        root_cause_identified=False,
+    )
+    assert result.breakdown.remediation_reward == pytest.approx(0.0)
+    assert result.breakdown.total_unclamped == pytest.approx(0.0)
+    assert result.reward == pytest.approx(0.01)
+
+
+def test_random_sequences_remain_clamped():
+    engine = RewardEngine()
+    rng = random.Random(42)
+    policies = list(DEFAULT_REWARD_POLICIES.items())
+    for _ in range(1000):
+        task_name, policy = rng.choice(policies)
+        event = rng.choice(tuple(policy.event_values.keys()))
+        result = engine.score(
+            task_name=task_name,
+            event=event,
+            duplicate=rng.choice((True, False)),
+            premature=rng.choice((True, False)),
+            destructive=rng.choice((True, False)),
+            root_cause_identified=rng.choice((True, False)),
+            resolved=rng.choice((True, False)),
+            step_number=rng.randint(1, 120),
+            max_steps=rng.randint(1, 120),
+        )
+        assert 0.01 <= result.reward <= 0.99

--- a/uv.lock
+++ b/uv.lock
@@ -322,6 +322,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cfgv"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.7"
 source = { registry = "https://pypi.org/simple" }
@@ -607,6 +616,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6c/c4/2ce2ca1451487dc7d59f09334c3fa1182c46cfcf0a2d5f19f9b26d53ac74/cyclopts-4.10.1.tar.gz", hash = "sha256:ad4e4bb90576412d32276b14a76f55d43353753d16217f2c3cd5bdceba7f15a0", size = 166623, upload-time = "2026-03-23T14:43:01.098Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0b/2261922126b2e50c601fe22d7ff5194e0a4d50e654836260c0665e24d862/cyclopts-4.10.1-py3-none-any.whl", hash = "sha256:35f37257139380a386d9fe4475e1e7c87ca7795765ef4f31abba579fcfcb6ecd", size = 204331, upload-time = "2026-03-23T14:43:02.625Z" },
+]
+
+[[package]]
+name = "distlib"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
 ]
 
 [[package]]
@@ -956,6 +974,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/88/bb/62c7aa86f63a05e2f9b96642fdef9b94526a23979820b09f5455deff4983/huggingface_hub-1.9.0.tar.gz", hash = "sha256:0ea5be7a56135c91797cae6ad726e38eaeb6eb4b77cefff5c9d38ba0ecf874f7", size = 750326, upload-time = "2026-04-03T08:35:55.888Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/73/37/0d15d16150e1829f3e90962c99f28257f6de9e526a680b4c6f5acdb54fd2/huggingface_hub-1.9.0-py3-none-any.whl", hash = "sha256:2999328c058d39fd19ab748dd09bd4da2fbaa4f4c1ddea823eab103051e14a1f", size = 637355, upload-time = "2026-04-03T08:35:53.897Z" },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
 ]
 
 [[package]]
@@ -1460,6 +1487,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
 name = "numpy"
 version = "2.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1884,6 +1920,7 @@ dependencies = [
 dev = [
     { name = "httpx" },
     { name = "mypy" },
+    { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -1898,6 +1935,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "openai", specifier = ">=1.30.0" },
     { name = "openenv-core", specifier = ">=0.2.0" },
+    { name = "pre-commit", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
@@ -1905,6 +1943,22 @@ requires-dist = [
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.29.0" },
 ]
 provides-extras = ["dev"]
+
+[[package]]
+name = "pre-commit"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
+]
 
 [[package]]
 name = "py-key-value-aio"
@@ -2165,6 +2219,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-discovery"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/ef/3bae0e537cfe91e8431efcba4434463d2c5a65f5a89edd47c6cf2f03c55f/python_discovery-1.2.2.tar.gz", hash = "sha256:876e9c57139eb757cb5878cbdd9ae5379e5d96266c99ef731119e04fffe533bb", size = 58872, upload-time = "2026-04-07T17:28:49.249Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/db/795879cc3ddfe338599bddea6388cc5100b088db0a4caf6e6c1af1c27e04/python_discovery-1.2.2-py3-none-any.whl", hash = "sha256:e1ae95d9af875e78f15e19aed0c6137ab1bb49c200f21f5061786490c9585c7a", size = 31894, upload-time = "2026-04-07T17:28:48.09Z" },
 ]
 
 [[package]]
@@ -2759,6 +2826,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
     { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
     { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "21.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0c/98/3a7e644e19cb26133488caff231be390579860bbbb3da35913c49a1d0a46/virtualenv-21.2.4.tar.gz", hash = "sha256:b294ef68192638004d72524ce7ef303e9d0cf5a44c95ce2e54a7500a6381cada", size = 5850742, upload-time = "2026-04-14T22:15:31.438Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/8d/edd0bd910ff803c308ee9a6b7778621af0d10252219ad9f19ef4d4982a61/virtualenv-21.2.4-py3-none-any.whl", hash = "sha256:29d21e941795206138d0f22f4e45ff7050e5da6c6472299fb7103318763861ac", size = 5831232, upload-time = "2026-04-14T22:15:29.342Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Fixes #5

## Root cause
`server/reward.py` did not compose the cross-task memory events into every default policy and did not enforce the ADR-13 diagnosis gate for `remediation.*` events. This left memory tags unscored and allowed remediation scoring paths before diagnosis in some policy shapes.

## What changed and why
- Added `_MEMORY_EVENTS` and `_with_memory_events(events)` in `server/reward.py`, and wrapped every `DEFAULT_REWARD_POLICIES[*].event_values` through the helper to inject all six memory tags without mutating the original event mappings.
- Updated `RewardEngine.score()` to:
  - route `memory.*` events into reward accumulation,
  - enforce the diagnosis evidence gate by returning a zeroed pre-clamp breakdown when `event.startswith("remediation.")` and `root_cause_identified=False`.
- Added tests in `tests/test_reward.py` for:
  - memory tags present in all default policies,
  - `memory.recall_memory.after_cutoff` scoring `+0.08` pre-clamp,
  - 1000 random sequences staying within `[0.01, 0.99]`,
  - remediation requiring diagnosis (one row per task).
- Updated issue-linked plan docs to keep plan and implementation aligned:
  - `idea/Plan/Architecture/RewardPolicy.md`
  - `idea/Plan/Architecture/MemoryModel.md`
  - `idea/Plan/Project/DecisionLog.md`

## Assumption
I treated the issue acceptance phrase "returns 0" as a pre-clamp requirement (`total_unclamped == 0.0`), while final public reward remains bounded by `clamp_reward` to `0.01`.

## How to test
- `uv run pytest -q tests/test_reward.py`
- `uv run pytest -q tests/test_memory.py`
