### PR TITLE
fix(ci): prevent auto-review bot failure on permission-restricted PRs

### DIFF
--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -182,10 +182,18 @@ jobs:
               // GitHub forbids the bot from REQUEST_CHANGES on PR authors of repo admins;
               // fall back to a plain comment so the signal is still visible.
               core.warning(`createReview ${event} failed (${e.message}); falling back to comment`);
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
-                body: body,
-              });
+              try {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.payload.pull_request.number,
+                  body: body,
+                });
+              } catch (commentError) {
+                // On fork-triggered pull_request runs, token permissions can block
+                // both review and issue-comment APIs. Keep CI green and surface context.
+                core.warning(
+                  `createComment failed (${commentError.message}); skipping bot comment due to token permissions`
+                );
+              }
             }


### PR DESCRIPTION
## Summary
- harden `auto-review.yml` by wrapping the fallback `issues.createComment` call in its own `try/catch`
- keep the static-checks workflow green when GitHub returns `403 Resource not accessible by integration`
- preserve observability with explicit warning logs when both review and comment APIs are blocked

## Test plan
- [x] trigger path reviewed against failing run logs showing `createReview` then `createComment` 403
- [x] validate workflow file diff only changes fallback error handling path
- [x] verify local git state is clean after commit and branch push