### PR TITLE
fix: parse memory commands in command parser

### DIFF
--- a/praxis_env/models.py
+++ b/praxis_env/models.py
@@ -101,6 +101,9 @@ class PraxisAction(BaseModel):
         scale_resource service=<name> resource=<type> [value=<N>]
         kill_query service=<name> query_id=<id>
         escalate reason=<text>
+        save_finding key=<key> value=<finding>
+        recall_memory
+        recall_memory key=<key>
 
     Example:
         PraxisAction(command="query_logs service=auth timerange=5m")
@@ -187,6 +190,9 @@ AVAILABLE_COMMANDS: list[str] = [
     "scale_resource service=<name> resource=<type>",
     "kill_query service=<name> query_id=<id>",
     "escalate reason=<text>",
+    "save_finding key=<key> value=<finding>",
+    "recall_memory",
+    "recall_memory key=<key>",
 ]
 
 VALID_METRICS: frozenset[str] = frozenset(

--- a/server/command_parser.py
+++ b/server/command_parser.py
@@ -9,6 +9,7 @@ Grammar:
 
 Special cases:
     - escalate: reason=<free text with spaces>
+    - save_finding: key=<key> value=<free text with spaces>
     - diagnose:  root_cause=<value with underscores or hyphens>
     - timerange: value like "5m", "15m" (kept as-is, not parsed to int)
 
@@ -37,6 +38,8 @@ KNOWN_ACTIONS: frozenset[str] = frozenset(
         "scale_resource",
         "kill_query",
         "escalate",
+        "save_finding",
+        "recall_memory",
     }
 )
 
@@ -48,6 +51,7 @@ def parse_command(raw: str) -> ParsedCommand:
     Handles:
     - Standard "key=value" pairs split by whitespace
     - "escalate reason=<free text>" — everything after "reason=" is the reason
+    - "save_finding key=<k> value=<free text>" — value captures remaining text
     - Empty or whitespace-only strings → empty ParsedCommand
     - Unknown action types → valid ParsedCommand with unknown action_type
 
@@ -94,6 +98,20 @@ def parse_command(raw: str) -> ParsedCommand:
         else:
             # No reason= key — treat whole remainder as reason
             params["reason"] = remainder.strip("'\"")
+        return ParsedCommand(action_type=action_type, params=params, raw=raw)
+
+    # Special case: save_finding key=<k> value=<free text>
+    # Value can include spaces, so parse with a regex anchored on value=
+    if action_type == "save_finding":
+        finding_match = re.search(
+            r"key=([^\s]+)\s+value=(.+)$", remainder, re.IGNORECASE
+        )
+        if finding_match:
+            params["key"] = finding_match.group(1).strip().strip("'\"")
+            params["value"] = finding_match.group(2).strip().strip("'\"")
+        else:
+            # Let environment-side validation reject malformed payloads
+            params = {}
         return ParsedCommand(action_type=action_type, params=params, raw=raw)
 
     # Standard key=value parsing for all other commands

--- a/tests/test_command_parser.py
+++ b/tests/test_command_parser.py
@@ -85,6 +85,28 @@ class TestParseCommand:
         assert cmd.action_type == "escalate"
         assert cmd.params.get("reason") == "something went very wrong"
 
+    # ── Memory actions ────────────────────────────────────────────────────────
+
+    def test_save_finding_free_text_value(self):
+        cmd = parse_command("save_finding key=db_pool value=exhausted at step 4")
+        assert cmd.action_type == "save_finding"
+        assert cmd.params == {"key": "db_pool", "value": "exhausted at step 4"}
+
+    def test_save_finding_bogus_without_value(self):
+        cmd = parse_command("save_finding key=db_pool exhausted at step 4")
+        assert cmd.action_type == "save_finding"
+        assert cmd.params == {}
+
+    def test_recall_memory_no_args(self):
+        cmd = parse_command("recall_memory")
+        assert cmd.action_type == "recall_memory"
+        assert cmd.params == {}
+
+    def test_recall_memory_with_key(self):
+        cmd = parse_command("recall_memory key=db_pool")
+        assert cmd.action_type == "recall_memory"
+        assert cmd.params == {"key": "db_pool"}
+
     # ── Edge cases ────────────────────────────────────────────────────────────
 
     def test_empty_string(self):
@@ -142,6 +164,8 @@ class TestIsKnownAction:
             "scale_resource",
             "kill_query",
             "escalate",
+            "save_finding",
+            "recall_memory",
         ]
         for action in known:
             assert is_known_action(action), f"{action} should be known"


### PR DESCRIPTION
## Summary
- Fixes #4.
- Root cause: `server/command_parser.py` only special-cased free-text parsing for `escalate reason=...`; it did not support `save_finding key=<k> value=<free text>` and did not include memory actions consistently in known/advertised command sets.
- Added `save_finding` and `recall_memory` to `KNOWN_ACTIONS`, implemented `save_finding` regex parsing (`key=([^\s]+)\s+value=(.+)$`) with malformed payloads returning empty params for env-side rejection, and updated `AVAILABLE_COMMANDS` in `praxis_env/models.py`.
- Added parser tests for valid/invalid `save_finding` and both `recall_memory` forms.
- Assumption: plan-doc updates requested in the issue are already present in `idea/Plan/Architecture/MemoryModel.md` §5, so no additional doc change was required here.

## Test plan
- [x] `python -m pytest tests/test_command_parser.py -q`
- [x] `python -m pytest tests/test_models.py -q`
- [x] Manual traces:
  - `save_finding key=db_pool value=exhausted at step 4` -> `{'key': 'db_pool', 'value': 'exhausted at step 4'}`
  - `recall_memory` -> `{}`
  - `recall_memory key=db_pool` -> `{'key': 'db_pool'}`
  - malformed `save_finding` without `value=` -> `{}`