### PR TITLE
fix: wire memory cutoff flow in PraxisEnvironment

### DIFF
--- a/idea/Plan/Architecture/DataFlow.md
+++ b/idea/Plan/Architecture/DataFlow.md
@@ -91,6 +91,8 @@ Key invariants:
 
 ## 3. Step flow (with memory branch)
 
+Status: shipped in Issue #6 (`server/praxis_environment.py` + `server/session_manager.py`).
+
 ```mermaid
 sequenceDiagram
     autonumber
@@ -116,6 +118,9 @@ sequenceDiagram
         PE->>M: save / recall
         PE->>RE: score(memory.save_finding.<cutoff_state>) or<br/>score(memory.recall_memory.<cutoff_state>)
         M-->>PE: result_text
+    else action_type in {query_logs, check_logs} and step >= cutoff
+        PE->>RE: score(memory.illegal_log_after_cutoff)
+        PE-->>PE: append [CONTEXT LIMIT] marker to result text
     else scenario action
         PE->>SC: step(parsed)
         SC->>RE: _score_event(event)

--- a/idea/Plan/Architecture/MemoryModel.md
+++ b/idea/Plan/Architecture/MemoryModel.md
@@ -41,6 +41,8 @@ class PraxisMemory:
 
 ## 2. Lifecycle
 
+Status: shipped in Issue #6 (`PraxisEnvironment` now owns memory command routing and cutoff rewriting).
+
 ```mermaid
 sequenceDiagram
     participant E as PraxisEnvironment
@@ -48,7 +50,7 @@ sequenceDiagram
     participant SC as Scenario
 
     Note over E: reset()
-    E->>M: PraxisMemory()  (or M.reset())
+    E->>M: PraxisMemory()  (constructed once in __init__)
     E->>SC: scenario.reset(episode_id)
 
     loop each step
@@ -61,6 +63,10 @@ sequenceDiagram
             M-->>E: stored value(s)
         else scenario action
             E->>SC: step(parsed)
+        end
+        alt action in {query_logs, check_logs} and step >= cutoff
+            E->>E: emit memory.illegal_log_after_cutoff
+            E->>E: append [CONTEXT LIMIT] guardrail line
         end
         E->>M: get_observation_context(history, step)
         M-->>E: full log slice OR cutoff message

--- a/idea/Plan/Architecture/SessionLifecycle.md
+++ b/idea/Plan/Architecture/SessionLifecycle.md
@@ -75,11 +75,13 @@ Calling `/step` against a `done=true` session returns 400 with `detail="Episode 
 session.allocate()
 └── PraxisEnvironment.__init__()
     └── PraxisMemory()                          # empty
-session.allocate() ↦ env.reset(task)
+session.allocate() ↦ env.reset(task, session_id=<uuid4>)
 ├── scenario.reset(episode_id)                   # scenario state cleared
 └── memory.reset()                               # findings cleared
 loop /step
 ├── if action ∈ {save, recall} → mutate memory
+├── if action ∈ {query_logs, check_logs} and cutoff active
+│   └── emit memory.illegal_log_after_cutoff + context-limit marker
 └── observation.investigation_result =
     memory.get_observation_context(history, step)
 session.close() (LRU or explicit)

--- a/server/praxis_environment.py
+++ b/server/praxis_environment.py
@@ -179,11 +179,12 @@ class PraxisEnvironment:
         # Parse command string -> structured ParsedCommand
         parsed = parse_command(action.command)
         current_step = self._scenario._step_count
-        cutoff_active = self._memory.is_active(current_step)
         reward_event: str | None = None
 
         if parsed.action_type in {"save_finding", "recall_memory"}:
-            outcome, reward_event = self._handle_memory_action(parsed.action_type, parsed.params)
+            outcome, reward_event = self._handle_memory_action(
+                parsed.action_type, parsed.params
+            )
         elif (
             parsed.action_type in {"query_logs", "check_logs"}
             and current_step >= self._memory.CONTEXT_CUTOFF_STEP

--- a/server/praxis_environment.py
+++ b/server/praxis_environment.py
@@ -31,12 +31,14 @@ from praxis_env.models import (
     PraxisAction,
     PraxisObservation,
     PraxisState,
+    StepOutcome,
     ensure_ascii_text,
 )
+from praxis_env.memory import PraxisMemory
 from praxis_env.scenarios import get_scenario, list_tasks
-from praxis_env.scenarios.base import BaseScenario, StepOutcome
+from praxis_env.scenarios.base import BaseScenario
 from server.command_parser import parse_command
-from server.reward import MAX_REWARD, MIN_REWARD
+from server.reward import MAX_REWARD, MIN_REWARD, RewardEngine
 
 logger = logging.getLogger(__name__)
 
@@ -72,6 +74,10 @@ class PraxisEnvironment:
     def __init__(self) -> None:
         self._scenario: BaseScenario | None = None
         self._episode_count: int = 0
+        self._memory = PraxisMemory()
+        self._reward_engine = RewardEngine()
+        self._investigation_history: list[str] = []
+        self._session_id: str = ""
 
     @staticmethod
     def resolve_task_name(task_name: str) -> str:
@@ -87,6 +93,7 @@ class PraxisEnvironment:
         self,
         task_name: str = "single-service-alert",
         seed: int | None = None,
+        session_id: str = "",
     ) -> PraxisObservation:
         """
         Start a new episode with the named scenario.
@@ -115,6 +122,15 @@ class PraxisEnvironment:
         )
 
         self._scenario = get_scenario(canonical_task_name)
+        cutoff = getattr(
+            self._scenario,
+            "MEMORY_CUTOFF_OVERRIDE",
+            PraxisMemory.CONTEXT_CUTOFF_STEP,
+        )
+        self._memory.CONTEXT_CUTOFF_STEP = int(cutoff)
+        self._memory.reset()
+        self._investigation_history = []
+        self._session_id = session_id
         self._scenario.reset(episode_id=episode_id)
 
         obs = self._scenario.get_observation()
@@ -122,6 +138,8 @@ class PraxisEnvironment:
         obs.investigation_result = ensure_ascii_text(
             self._scenario.get_initial_observation_text()
         )
+        obs.memory_active = self._memory.is_active(self._scenario._step_count)
+        obs.saved_findings_count = len(self._memory.saved_findings)
         return obs
 
     def step(self, action: PraxisAction) -> dict[str, Any]:
@@ -160,9 +178,33 @@ class PraxisEnvironment:
         # Scenarios return domain outcomes without mutating those counters.
         # Parse command string -> structured ParsedCommand
         parsed = parse_command(action.command)
+        current_step = self._scenario._step_count
+        cutoff_active = self._memory.is_active(current_step)
+        reward_event: str | None = None
 
-        # Delegate to active scenario
-        outcome: StepOutcome = self._scenario.step(parsed)
+        if parsed.action_type in {"save_finding", "recall_memory"}:
+            outcome, reward_event = self._handle_memory_action(parsed.action_type, parsed.params)
+        elif (
+            parsed.action_type in {"query_logs", "check_logs"}
+            and current_step >= self._memory.CONTEXT_CUTOFF_STEP
+        ):
+            reward_event = "memory.illegal_log_after_cutoff"
+            result_text = (
+                "Log access is disabled after context cutoff.\n"
+                "[CONTEXT LIMIT] Use save_finding and recall_memory instead."
+            )
+            reward = self._score_memory_event(reward_event)
+            outcome = StepOutcome(
+                investigation_result=result_text,
+                reward=reward,
+                done=self._scenario.is_done(),
+                incident_resolved=self._scenario._incident_resolved,
+                root_cause_identified=self._scenario._root_cause_identified,
+                info={"event": reward_event},
+            )
+        else:
+            # Delegate to active scenario
+            outcome = self._scenario.step(parsed)
         raw_step_reward = self._scenario.clamp_reward(outcome.reward)
         current_cumulative_reward = self._scenario.clamp_reward(
             self._scenario._cumulative_reward
@@ -190,6 +232,7 @@ class PraxisEnvironment:
 
         # Update scenario's investigation result for next observation
         self._scenario._last_investigation_result = outcome.investigation_result
+        self._investigation_history.append(outcome.investigation_result)
         self._scenario._step_count += 1
         self._scenario._cumulative_reward = next_cumulative_reward
 
@@ -197,8 +240,18 @@ class PraxisEnvironment:
         obs = self._scenario.get_observation()
         # Override step_number to reflect the step just taken
         obs.step_number = self._scenario._step_count
+        memory_active = self._memory.is_active(self._scenario._step_count)
+        if memory_active:
+            obs.investigation_result = self._memory.get_observation_context(
+                self._investigation_history,
+                self._scenario._step_count,
+            )
+        obs.memory_active = memory_active
+        obs.saved_findings_count = len(self._memory.saved_findings)
 
         info = dict(outcome.info or {})
+        if reward_event is not None:
+            info["event"] = reward_event
         if score_cap_reached:
             info["score_cap_reached"] = True
 
@@ -229,7 +282,10 @@ class PraxisEnvironment:
         """
         if self._scenario is None:
             raise RuntimeError("state() called before reset(). Call reset() first.")
-        return self._scenario.get_state()
+        state = self._scenario.get_state()
+        state.memory_active = self._memory.is_active(self._scenario._step_count)
+        state.session_id = self._session_id
+        return state
 
     def list_tasks(self) -> list[str]:
         """Return all available task names."""
@@ -250,3 +306,65 @@ class PraxisEnvironment:
             "memory_active": obs.memory_active,
             "saved_findings_count": obs.saved_findings_count,
         }
+
+    def _score_memory_event(self, event: str) -> float:
+        """Score memory event tags through the shared reward engine."""
+        if self._scenario is None:
+            raise RuntimeError("Cannot score memory event before reset().")
+        result = self._reward_engine.score(
+            task_name=self._scenario.NAME,
+            event=event,
+            step_number=self._scenario._step_count + 1,
+            max_steps=self._scenario.MAX_STEPS,
+            root_cause_identified=self._scenario._root_cause_identified,
+        )
+        return result.reward
+
+    def _handle_memory_action(
+        self,
+        action_type: str,
+        params: dict[str, str],
+    ) -> tuple[StepOutcome, str]:
+        """Execute a memory command and return deterministic outcome + event tag."""
+        if self._scenario is None:
+            raise RuntimeError("Cannot handle memory action before reset().")
+
+        cutoff_state = (
+            "after_cutoff"
+            if self._memory.is_active(self._scenario._step_count)
+            else "before_cutoff"
+        )
+
+        if action_type == "save_finding":
+            key = params.get("key", "").strip()
+            value = params.get("value", "").strip()
+            if not key or not value:
+                event = "invalid_input"
+                result_text = (
+                    "Invalid save_finding command.\n"
+                    "Expected: save_finding key=<key> value=<finding>"
+                )
+                reward = self._score_memory_event(event)
+            else:
+                event = f"memory.save_finding.{cutoff_state}"
+                result_text = self._memory.save_finding(key, value)
+                reward = self._score_memory_event(event)
+        else:
+            key = params.get("key")
+            has_findings = bool(self._memory.saved_findings)
+            if cutoff_state == "after_cutoff" and not has_findings:
+                event = "memory.empty_recall_after_cutoff"
+            else:
+                event = f"memory.recall_memory.{cutoff_state}"
+            result_text = self._memory.recall_memory(key=key)
+            reward = self._score_memory_event(event)
+
+        outcome = StepOutcome(
+            investigation_result=result_text,
+            reward=reward,
+            done=self._scenario.is_done(),
+            incident_resolved=self._scenario._incident_resolved,
+            root_cause_identified=self._scenario._root_cause_identified,
+            info={"event": event},
+        )
+        return outcome, event

--- a/server/session_manager.py
+++ b/server/session_manager.py
@@ -59,10 +59,10 @@ class SessionManager:
         `seed` is accepted for API compatibility; deterministic scenarios may
         ignore it until procedural tasks are introduced.
         """
-        env = PraxisEnvironment()
-        observation = env.reset(task_name=task_name, seed=seed)
-        now = time.time()
         session_id = str(uuid4())
+        env = PraxisEnvironment()
+        observation = env.reset(task_name=task_name, seed=seed, session_id=session_id)
+        now = time.time()
         session = Session(
             session_id=session_id,
             env=env,

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -10,6 +10,7 @@ in Phases 3-5.
 """
 
 import pytest
+from praxis_env.scenarios.single_service_alert import SingleServiceAlertScenario
 from server.praxis_environment import PraxisEnvironment
 from praxis_env.models import PraxisAction
 
@@ -98,6 +99,49 @@ class TestCommandParserIntegration:
         cmd = parse_command("escalate reason=everything is on fire please help")
         assert cmd.action_type == "escalate"
         assert cmd.params["reason"] == "everything is on fire please help"
+
+
+class TestMemoryHookIntegration:
+    def test_state_includes_session_id_from_reset(self):
+        env = PraxisEnvironment()
+        env.reset(task_name="single-service-alert", session_id="session-123")
+        state = env.state()
+        assert state.session_id == "session-123"
+        assert state.memory_active is False
+
+    def test_save_finding_is_routed_by_environment(self):
+        env = PraxisEnvironment()
+        env.reset(task_name="single-service-alert")
+        result = env.step(
+            PraxisAction(command="save_finding key=root_cause value=db_pool_exhausted")
+        )
+        assert result["info"]["event"] == "memory.save_finding.before_cutoff"
+        assert result["observation"]["saved_findings_count"] == 1
+        assert result["observation"]["memory_active"] is False
+
+    def test_cutoff_rewrite_and_illegal_log_penalty(self, monkeypatch):
+        monkeypatch.setattr(
+            SingleServiceAlertScenario, "MEMORY_CUTOFF_OVERRIDE", 1, raising=False
+        )
+        env = PraxisEnvironment()
+        env.reset(task_name="single-service-alert")
+
+        step1 = env.step(PraxisAction(command="save_finding key=rca value=bad_config"))
+        assert step1["observation"]["memory_active"] is True
+        assert (
+            "[CONTEXT LIMIT REACHED - Step 1/1]"
+            in step1["observation"]["investigation_result"]
+        )
+
+        step2 = env.step(PraxisAction(command="query_logs service=auth timerange=5m"))
+        assert step2["info"]["event"] == "memory.illegal_log_after_cutoff"
+        assert step2["reward"] == pytest.approx(0.01)
+        assert step2["observation"]["memory_active"] is True
+        assert step2["observation"]["saved_findings_count"] == 1
+        assert (
+            "[CONTEXT LIMIT REACHED - Step 2/1]"
+            in step2["observation"]["investigation_result"]
+        )
 
 
 class TestObsToDict:

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -1,0 +1,10 @@
+"""tests/test_session_manager.py - Session allocation behavior."""
+
+from server.session_manager import SessionManager
+
+
+def test_allocate_passes_session_id_into_environment_state():
+    manager = SessionManager(max_sessions=4)
+    allocation = manager.allocate(task_name="single-service-alert")
+    state = allocation.session.env.state()
+    assert state.session_id == allocation.session.session_id


### PR DESCRIPTION
- Fixes #6

## Root cause
`PraxisEnvironment.step()` still routed all parsed actions into scenario handlers, so memory commands (`save_finding`/`recall_memory`), cutoff enforcement, and session-scoped memory state were not integrated at the environment boundary where they belong.

## What changed and why
- Wired `PraxisEnvironment` to own a single `PraxisMemory` instance, reset it on every `reset`, apply per-scenario cutoff override, and persist `session_id` for `state()`.
- Routed `save_finding`/`recall_memory` directly in `PraxisEnvironment.step()` with memory reward events (`memory.<action>.<before|after>_cutoff`).
- Added post-cutoff guardrail for `query_logs`/`check_logs`: emit `memory.illegal_log_after_cutoff` and append a context-limit marker.
- Applied observation rewrite after each step: when memory is active, `investigation_result` comes from `PraxisMemory.get_observation_context(...)`; always set `memory_active` and `saved_findings_count`.
- Passed `session_id` from `SessionManager.allocate()` into `env.reset(..., session_id=...)` and mirrored it in `state()`.
- Updated architecture docs requested by the issue (`DataFlow`, `MemoryModel`, `SessionLifecycle`) to mark the shipped step/memory/session behavior.
- Added regression tests for memory routing, cutoff behavior, and session-id propagation.

## Assumption
- `check_logs` is treated as a log-query alias for cutoff enforcement even though current parser action set does not emit it yet.

## How to test
- `uv run pytest tests/test_environment.py tests/test_session_manager.py tests/test_api_sessions.py tests/test_reward.py -q`
- Manual trace:
  - reset with session, issue `save_finding` and `recall_memory` before/after cutoff, confirm memory event tags.
  - after cutoff, run `query_logs ...` and confirm `memory.illegal_log_after_cutoff` event and memory banner in observation.
  - call `/state` and confirm `session_id` + `memory_active` fields.