### PR TITLE
fix: implement seeded procedural incident generator

### DIFF
--- a/idea/Plan/Architecture/RewardPolicy.md
+++ b/idea/Plan/Architecture/RewardPolicy.md
@@ -144,7 +144,7 @@ Sparse milestone rewards by design. See [`ScenarioCatalog.md`](./ScenarioCatalog
 
 ---
 
-## 4. NEW `procedural-incident` (seeded)
+## 4. `procedural-incident` (seeded, shipped in Issue #8)
 
 Reward map is **built at scenario init** by `_build_procedural_policy(difficulty)`. Skeleton:
 

--- a/idea/Plan/Architecture/ScenarioCatalog.md
+++ b/idea/Plan/Architecture/ScenarioCatalog.md
@@ -130,7 +130,7 @@ Resolution rule: incident resolves only after all 3 root causes are diagnosed AN
 
 ---
 
-## 4. NEW Scenario 6 — `procedural-incident` (seeded generator)
+## 4. Scenario 6 — `procedural-incident` (seeded generator, shipped in Issue #8)
 
 Infinite unique incidents from a deterministic seed. Turns Praxis from "4 tasks" into "∞ tasks" — the production training asset.
 

--- a/idea/Plan/Project/DecisionLog.md
+++ b/idea/Plan/Project/DecisionLog.md
@@ -192,6 +192,16 @@ Trade-off accepted: small duplication with `/metadata` (which lists tasks) and `
 
 ---
 
+## ADR-15 — Procedural generator shipped with diagnosis gate (NEW)
+
+**Date**: 2026-04-25 · **Status**: Accepted · **Issue**: #8 · **Source**: ADR-07, ADR-13, `tests/test_task6_procedural.py`.
+
+Issue #8 ships the `procedural-incident` scenario from ADR-07 as a seeded deterministic generator with difficulty tiers (`easy`/`medium`/`hard`) and runtime-stamped `MAX_STEPS` + `MEMORY_CUTOFF_OVERRIDE`.
+
+Cross-link to ADR-13: the new scenario enforces a hard evidence gate where remediation attempts before diagnosis score zero (clamped at the shared floor in emitted rewards), with explicit tests across all three procedural difficulties.
+
+---
+
 ## How to add a new ADR
 
 1. Append at the bottom with the next number.

--- a/praxis_env/scenarios/__init__.py
+++ b/praxis_env/scenarios/__init__.py
@@ -12,6 +12,7 @@ from praxis_env.scenarios.cascading_failure import CascadingFailureScenario
 from praxis_env.scenarios.ambiguous_incident import AmbiguousIncidentScenario
 from praxis_env.scenarios.memory_leak_scenario import MemoryLeakScenario
 from praxis_env.scenarios.mega_incident import MegaIncidentScenario
+from praxis_env.scenarios.procedural_incident import ProceduralIncidentScenario
 
 # Populated as phases complete. Add new scenarios here.
 SCENARIO_REGISTRY: dict[str, type[BaseScenario]] = {
@@ -20,10 +21,16 @@ SCENARIO_REGISTRY: dict[str, type[BaseScenario]] = {
     "ambiguous-incident": AmbiguousIncidentScenario,
     "memory-leak": MemoryLeakScenario,
     "cascading-platform-failure": MegaIncidentScenario,
+    "procedural-incident": ProceduralIncidentScenario,
 }
 
 
-def get_scenario(task_name: str) -> BaseScenario:
+def get_scenario(
+    task_name: str,
+    *,
+    seed: int | None = None,
+    difficulty: str | None = None,
+) -> BaseScenario:
     """
     Instantiate a registered scenario by task name.
 
@@ -39,6 +46,10 @@ def get_scenario(task_name: str) -> BaseScenario:
     if task_name not in SCENARIO_REGISTRY:
         available = ", ".join(sorted(SCENARIO_REGISTRY.keys()))
         raise ValueError(f"Unknown task: '{task_name}'. Available tasks: [{available}]")
+    if task_name == "procedural-incident":
+        return SCENARIO_REGISTRY[task_name](
+            seed=seed, difficulty=difficulty or "medium"
+        )
     return SCENARIO_REGISTRY[task_name]()
 
 

--- a/praxis_env/scenarios/procedural_incident.py
+++ b/praxis_env/scenarios/procedural_incident.py
@@ -169,9 +169,7 @@ class ProceduralIncidentScenario(BaseScenario):
         remediation_action, remediation_service = remediation_command.split(" ", 1)
         self._correct_remediation_action = remediation_action
         self._correct_remediation_service = remediation_service
-        self._correct_remediation_event = (
-            f"remediation.{self._correct_remediation_action}.{self._correct_remediation_service}"
-        )
+        self._correct_remediation_event = f"remediation.{self._correct_remediation_action}.{self._correct_remediation_service}"
 
         self._reward_engine.register_policy(
             self.NAME, self._build_procedural_policy(self._difficulty)

--- a/praxis_env/scenarios/procedural_incident.py
+++ b/praxis_env/scenarios/procedural_incident.py
@@ -1,0 +1,458 @@
+"""
+praxis_env.scenarios.procedural_incident - Task 6: Seeded procedural incident.
+
+Generates deterministic scenario content from (seed, difficulty), enabling
+infinite reproducible incidents without global mutable state.
+"""
+
+from __future__ import annotations
+
+import random
+
+from praxis_env.scenarios.base import (
+    BaseScenario,
+    ParsedCommand,
+    StepOutcome,
+    get_metric_param,
+    get_service_param,
+)
+from server.reward import RewardPolicy
+
+
+class ProceduralIncidentScenario(BaseScenario):
+    """Seeded incident generator with difficulty-aware reward calibration."""
+
+    NAME = "procedural-incident"
+    SEVERITY = "P2"
+    MAX_STEPS = 25
+    MEMORY_CUTOFF_OVERRIDE = 15
+
+    ROOT_CAUSE_POOL = [
+        "db_connection",
+        "session_drift",
+        "dns_config",
+        "memory_leak",
+        "network_partition",
+        "cpu_exhaustion",
+        "disk_full",
+        "cert_expiry",
+    ]
+    RED_HERRING_POOL = [
+        "cache_miss_spike",
+        "queue_backlog",
+        "scheduled_maintenance",
+        "log_rotation",
+        "metric_collector_lag",
+        "cdn_rebalance",
+    ]
+    SERVICE_POOL = [
+        "api",
+        "auth",
+        "database",
+        "cache",
+        "worker",
+        "queue",
+        "cdn",
+        "dns",
+        "search",
+        "frontend",
+    ]
+
+    DIFFICULTY_CONFIG = {
+        "easy": {
+            "n_services": 1,
+            "n_red_herrings": 0,
+            "max_steps": 15,
+            "memory_cutoff": 8,
+        },
+        "medium": {
+            "n_services": 3,
+            "n_red_herrings": 2,
+            "max_steps": 25,
+            "memory_cutoff": 15,
+        },
+        "hard": {
+            "n_services": 5,
+            "n_red_herrings": 4,
+            "max_steps": 50,
+            "memory_cutoff": 25,
+        },
+    }
+
+    REMEDIATION_COMMAND_BY_ROOT_CAUSE: dict[str, str] = {
+        "db_connection": "restart_service database",
+        "session_drift": "rollback_deploy api",
+        "dns_config": "restart_service dns",
+        "memory_leak": "scale_resource worker",
+        "network_partition": "restart_service api",
+        "cpu_exhaustion": "scale_resource api",
+        "disk_full": "scale_resource database",
+        "cert_expiry": "rollback_deploy cdn",
+    }
+
+    def __init__(self, seed: int | None = None, difficulty: str = "medium"):
+        super().__init__()
+        resolved_difficulty = (difficulty or "medium").strip().lower()
+        if resolved_difficulty not in self.DIFFICULTY_CONFIG:
+            raise ValueError(
+                f"Unknown procedural difficulty '{difficulty}'. "
+                "Use one of: easy, medium, hard."
+            )
+        self._seed = int(seed) if seed is not None else None
+        self._rng = random.Random(seed)
+        self._difficulty = resolved_difficulty
+
+    def _build_procedural_policy(self, difficulty: str) -> RewardPolicy:
+        profile = {
+            "easy": {"diagnosis": 0.20, "remediation": 0.25, "step_cost": 0.0},
+            "medium": {"diagnosis": 0.15, "remediation": 0.20, "step_cost": 0.003},
+            "hard": {"diagnosis": 0.12, "remediation": 0.15, "step_cost": 0.005},
+        }[difficulty]
+
+        event_values = {
+            "investigation.query_logs.root": 0.08 if difficulty == "easy" else 0.05,
+            "investigation.query_logs.default": 0.04 if difficulty == "easy" else 0.025,
+            "investigation.check_metrics.root": 0.08 if difficulty == "easy" else 0.05,
+            "investigation.check_metrics.default": 0.04
+            if difficulty == "easy"
+            else 0.02,
+            "investigation.check_deps.default": 0.04 if difficulty == "easy" else 0.025,
+            "investigation.check_config.root": 0.09 if difficulty == "easy" else 0.045,
+            "investigation.check_config.default": 0.03
+            if difficulty == "easy"
+            else 0.02,
+            "investigation.check_runbook.default": 0.04
+            if difficulty == "easy"
+            else 0.025,
+            "diagnosis.correct": profile["diagnosis"],
+            "diagnosis.wrong": 0.0,
+            self._correct_remediation_event: profile["remediation"],
+            "remediation.wrong": 0.0,
+            "escalation.with_evidence": 0.15,
+            "escalation.no_evidence": 0.0,
+            "unknown_command": 0.0,
+            "invalid_input": 0.0,
+        }
+
+        return RewardPolicy(
+            event_values=event_values,
+            time_pressure_cost_per_step=profile["step_cost"],
+            destructive_penalty=-0.10,
+        )
+
+    def _reset_scenario_state(self) -> None:
+        cfg = self.DIFFICULTY_CONFIG[self._difficulty]
+        self.MAX_STEPS = int(cfg["max_steps"])
+        self.MEMORY_CUTOFF_OVERRIDE = int(cfg["memory_cutoff"])
+
+        self._done_investigations: set[str] = set()
+        self._chosen_root_cause = self._rng.choice(self.ROOT_CAUSE_POOL)
+        self._root_service = self._rng.choice(self.SERVICE_POOL)
+
+        n_services = int(cfg["n_services"])
+        n_red_herrings = int(cfg["n_red_herrings"])
+
+        other_services = [s for s in self.SERVICE_POOL if s != self._root_service]
+        sampled_services = self._rng.sample(other_services, k=max(0, n_services - 1))
+        self._scenario_services = [self._root_service, *sampled_services]
+
+        red_herrings = list(self.RED_HERRING_POOL)
+        self._chosen_red_herrings = (
+            self._rng.sample(red_herrings, k=min(n_red_herrings, len(red_herrings)))
+            if n_red_herrings > 0
+            else []
+        )
+
+        remediation_command = self.REMEDIATION_COMMAND_BY_ROOT_CAUSE[
+            self._chosen_root_cause
+        ]
+        remediation_action, remediation_service = remediation_command.split(" ", 1)
+        self._correct_remediation_action = remediation_action
+        self._correct_remediation_service = remediation_service
+        self._correct_remediation_event = (
+            f"remediation.{self._correct_remediation_action}.{self._correct_remediation_service}"
+        )
+
+        self._reward_engine.register_policy(
+            self.NAME, self._build_procedural_policy(self._difficulty)
+        )
+
+        self.INITIAL_SYSTEM_STATUS = {
+            service: ("critical" if service == self._root_service else "degraded")
+            for service in self._scenario_services
+        }
+        self.INITIAL_AFFECTED_SERVICES = list(self._scenario_services)
+        self._current_system_status = dict(self.INITIAL_SYSTEM_STATUS)
+
+        self._logs = {}
+        self._configs = {}
+        self._deps = {}
+        self._metrics = {}
+        for service in self._scenario_services:
+            is_root = service == self._root_service
+            root_tag = self._chosen_root_cause.replace("_", "-")
+            self._logs[service] = (
+                f"19:42:11 [ERROR] {service}: incident markers correlated with {root_tag}\n"
+                if is_root
+                else f"19:42:11 [WARN] {service}: downstream retries observed\n"
+            )
+            self._configs[service] = (
+                f"Recent config for {service}: root-cause candidate {self._chosen_root_cause}\n"
+                if is_root
+                else f"Recent config for {service}: no direct regression found\n"
+            )
+            self._deps[service] = (
+                f"{service} dependencies: root path includes {self._root_service}\n"
+            )
+            self._metrics[(service, "error_rate")] = (
+                "error_rate: 19.5% (root service anomaly)\n"
+                if is_root
+                else "error_rate: 4.2% (secondary impact)\n"
+            )
+            self._metrics[(service, "latency_p95")] = (
+                "latency_p95: 4200ms\n" if is_root else "latency_p95: 850ms\n"
+            )
+
+        self.ALERT_SUMMARY = (
+            "## PROCEDURAL INCIDENT\n\n"
+            f"Difficulty: {self._difficulty}\n"
+            f"Seed: {self._seed}\n"
+            f"Affected services: {', '.join(self._scenario_services)}\n"
+            f"Noise signals: {', '.join(self._chosen_red_herrings) or 'none'}\n\n"
+            "Investigate, diagnose, and remediate the incident."
+        )
+
+    def get_initial_observation_text(self) -> str:
+        return ""
+
+    def step(self, command: ParsedCommand) -> StepOutcome:
+        action = command.action_type
+        if action == "query_logs":
+            return self._handle_query_logs(command)
+        if action == "check_metrics":
+            return self._handle_check_metrics(command)
+        if action == "check_deps":
+            return self._handle_check_deps(command)
+        if action == "check_config":
+            return self._handle_check_config(command)
+        if action == "check_runbook":
+            return self._handle_check_runbook(command)
+        if action == "diagnose":
+            return self._handle_diagnose(command)
+        if action in (
+            "restart_service",
+            "rollback_deploy",
+            "scale_resource",
+            "kill_query",
+        ):
+            return self._handle_remediation(command)
+        if action == "escalate":
+            return self._handle_escalate(command)
+        return self._handle_unknown_command(command.raw)
+
+    def _handle_query_logs(self, command: ParsedCommand) -> StepOutcome:
+        service = get_service_param(command.params, default=self._root_service)
+        logs = self._logs.get(service)
+        if logs is None:
+            return self._invalid_input(f"No log data for service '{service}'.")
+
+        duplicate = self._is_duplicate(f"logs:{service}")
+        event = (
+            "investigation.query_logs.root"
+            if service == self._root_service
+            else "investigation.query_logs.default"
+        )
+        score = self._score_event(event, duplicate=duplicate)
+        return self._outcome(logs, score.reward)
+
+    def _handle_check_metrics(self, command: ParsedCommand) -> StepOutcome:
+        service = get_service_param(command.params, default=self._root_service)
+        metric = get_metric_param(command.params, default="error_rate")
+        metric_text = self._metrics.get((service, metric))
+        if metric_text is None:
+            return self._invalid_input(f"No metric '{metric}' for '{service}'.")
+
+        duplicate = self._is_duplicate(f"metric:{service}:{metric}")
+        event = (
+            "investigation.check_metrics.root"
+            if service == self._root_service
+            else "investigation.check_metrics.default"
+        )
+        score = self._score_event(event, duplicate=duplicate)
+        return self._outcome(metric_text, score.reward)
+
+    def _handle_check_deps(self, command: ParsedCommand) -> StepOutcome:
+        service = get_service_param(command.params, default=self._root_service)
+        deps = self._deps.get(service)
+        if deps is None:
+            return self._invalid_input(f"No dependency data for service '{service}'.")
+
+        duplicate = self._is_duplicate(f"deps:{service}")
+        score = self._score_event(
+            "investigation.check_deps.default", duplicate=duplicate
+        )
+        return self._outcome(deps, score.reward)
+
+    def _handle_check_config(self, command: ParsedCommand) -> StepOutcome:
+        service = get_service_param(command.params, default=self._root_service)
+        config = self._configs.get(service)
+        if config is None:
+            return self._invalid_input(f"No config data for service '{service}'.")
+
+        duplicate = self._is_duplicate(f"config:{service}")
+        event = (
+            "investigation.check_config.root"
+            if service == self._root_service
+            else "investigation.check_config.default"
+        )
+        score = self._score_event(event, duplicate=duplicate)
+        return self._outcome(config, score.reward)
+
+    def _handle_check_runbook(self, command: ParsedCommand) -> StepOutcome:
+        service = get_service_param(command.params, default=self._root_service)
+        runbook = (
+            f"RUNBOOK {service}:\n"
+            "1. Correlate logs and metrics.\n"
+            "2. Validate config and dependencies.\n"
+            "3. Diagnose before remediation.\n"
+        )
+        duplicate = self._is_duplicate(f"runbook:{service}")
+        score = self._score_event(
+            "investigation.check_runbook.default",
+            duplicate=duplicate,
+        )
+        return self._outcome(runbook, score.reward)
+
+    def _handle_diagnose(self, command: ParsedCommand) -> StepOutcome:
+        raw = command.params.get("root_cause", "").strip().lower()
+        normalized = raw.replace("-", "_").replace(" ", "_")
+        if normalized == self._chosen_root_cause:
+            self._root_cause_identified = True
+            score = self._score_event("diagnosis.correct")
+            return self._outcome(
+                (
+                    "Correct diagnosis.\n\n"
+                    f"Root cause confirmed: {self._chosen_root_cause}\n"
+                    f"Recommended remediation: "
+                    f"{self._correct_remediation_action} service={self._correct_remediation_service}"
+                ),
+                score.reward,
+                done=self.is_done(),
+                root_cause_identified=True,
+            )
+
+        score = self._score_event("diagnosis.wrong", premature=True)
+        return self._outcome(
+            f"Incorrect diagnosis: '{raw}'. Continue investigating.",
+            score.reward,
+            done=self.is_done(),
+            root_cause_identified=False,
+        )
+
+    def _handle_remediation(self, command: ParsedCommand) -> StepOutcome:
+        action = command.action_type
+        service = get_service_param(command.params, default=self._root_service)
+
+        if not self._root_cause_identified:
+            # Explicit evidence gate (ADR-13): no positive remediation score before diagnosis.
+            return self._outcome(
+                (
+                    "Remediation blocked: diagnose the root cause before "
+                    "applying remediation."
+                ),
+                0.0,
+                done=self.is_done(),
+                incident_resolved=False,
+                root_cause_identified=False,
+            )
+
+        if (
+            action == self._correct_remediation_action
+            and service == self._correct_remediation_service
+        ):
+            self._incident_resolved = True
+            self._current_system_status = {
+                service_name: "healthy" for service_name in self._current_system_status
+            }
+            score = self._score_event(self._correct_remediation_event, resolved=True)
+            return self._outcome(
+                "Remediation succeeded. Incident resolved.",
+                score.reward,
+                done=True,
+                incident_resolved=True,
+                root_cause_identified=True,
+            )
+
+        score = self._score_event("remediation.wrong", destructive=True)
+        return self._outcome(
+            f"Action '{action}' on '{service}' did not resolve the incident.",
+            score.reward,
+            done=self.is_done(),
+            incident_resolved=False,
+            root_cause_identified=True,
+        )
+
+    def _handle_escalate(self, command: ParsedCommand) -> StepOutcome:
+        investigations = len(self._done_investigations)
+        reason = command.params.get("reason", "")
+        if investigations >= 3:
+            self._incident_resolved = True
+            score = self._score_event("escalation.with_evidence", resolved=True)
+            return self._outcome(
+                (
+                    "Escalation accepted with evidence.\n"
+                    f"Investigations: {investigations}\n"
+                    f"Reason: {reason}"
+                ),
+                score.reward,
+                done=True,
+                incident_resolved=True,
+                root_cause_identified=self._root_cause_identified,
+            )
+
+        score = self._score_event("escalation.no_evidence", premature=True)
+        return self._outcome(
+            (
+                "Escalation filed without sufficient evidence. "
+                f"Investigations completed: {investigations}."
+            ),
+            score.reward,
+            done=True,
+            incident_resolved=False,
+            root_cause_identified=self._root_cause_identified,
+        )
+
+    def _is_duplicate(self, key: str) -> bool:
+        duplicate = key in self._done_investigations
+        if not duplicate:
+            self._done_investigations.add(key)
+        return duplicate
+
+    def _invalid_input(self, text: str) -> StepOutcome:
+        score = self._score_event("invalid_input")
+        return self._outcome(text, score.reward)
+
+    def _outcome(
+        self,
+        investigation_result: str,
+        reward: float,
+        *,
+        done: bool | None = None,
+        incident_resolved: bool | None = None,
+        root_cause_identified: bool | None = None,
+    ) -> StepOutcome:
+        return StepOutcome(
+            investigation_result=investigation_result,
+            reward=reward,
+            done=self.is_done() if done is None else done,
+            incident_resolved=(
+                self._incident_resolved
+                if incident_resolved is None
+                else incident_resolved
+            ),
+            root_cause_identified=(
+                self._root_cause_identified
+                if root_cause_identified is None
+                else root_cause_identified
+            ),
+        )

--- a/server/app.py
+++ b/server/app.py
@@ -134,6 +134,11 @@ def create_app() -> FastAPI:
                 {"name": "ambiguous-incident", "difficulty": "medium", "max_steps": 25},
                 {"name": "cascading-failure", "difficulty": "hard", "max_steps": 20},
                 {"name": "memory-leak", "difficulty": "hard", "max_steps": 25},
+                {
+                    "name": "procedural-incident",
+                    "difficulty": "medium",
+                    "max_steps": 25,
+                },
             ],
             "endpoints": {
                 "reset": "/reset",
@@ -204,7 +209,16 @@ def create_app() -> FastAPI:
                     data.get("task_name", "single-service-alert")
                     or "single-service-alert"
                 )
-                seed = data.get("seed")
+                raw_seed = data.get("seed")
+                if raw_seed is not None:
+                    if isinstance(raw_seed, bool) or not isinstance(raw_seed, int):
+                        raise HTTPException(
+                            status_code=400,
+                            detail="Invalid seed: expected integer",
+                        )
+                    seed = raw_seed
+        except HTTPException:
+            raise
         except Exception:
             pass  # no body or invalid JSON — use default task
 
@@ -216,6 +230,7 @@ def create_app() -> FastAPI:
             return {
                 "session_id": allocation.session.session_id,
                 "observation": obs_dict,
+                "metadata": allocation.metadata,
                 **obs_dict,
             }
         except ValueError as e:

--- a/server/praxis_environment.py
+++ b/server/praxis_environment.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import logging
 import math
+import random
 from typing import Any
 
 from praxis_env.models import (
@@ -48,6 +49,7 @@ TASK_NAME_ALIASES: dict[str, str] = {
     "medium": "ambiguous-incident",
     "hard": "cascading-failure",
 }
+PROCEDURAL_DIFFICULTIES = frozenset({"easy", "medium", "hard"})
 
 
 class PraxisEnvironment:
@@ -74,6 +76,7 @@ class PraxisEnvironment:
     def __init__(self) -> None:
         self._scenario: BaseScenario | None = None
         self._episode_count: int = 0
+        self._last_reset_metadata: dict[str, Any] = {}
         self._memory = PraxisMemory()
         self._reward_engine = RewardEngine()
         self._investigation_history: list[str] = []
@@ -86,6 +89,31 @@ class PraxisEnvironment:
         if not normalized:
             normalized = "single-service-alert"
         return TASK_NAME_ALIASES.get(normalized, normalized)
+
+    @staticmethod
+    def resolve_task_request(task_name: str) -> tuple[str, str | None]:
+        """Resolve canonical task name and optional procedural difficulty."""
+        normalized = (task_name or "single-service-alert").strip().lower()
+        if not normalized:
+            normalized = "single-service-alert"
+
+        if normalized.startswith("procedural-incident"):
+            if normalized == "procedural-incident":
+                return "procedural-incident", "medium"
+            if ":" in normalized:
+                _, _, suffix = normalized.partition(":")
+                if suffix in PROCEDURAL_DIFFICULTIES:
+                    return "procedural-incident", suffix
+            if normalized.count("-") >= 2:
+                suffix = normalized.rsplit("-", 1)[-1]
+                if suffix in PROCEDURAL_DIFFICULTIES:
+                    return "procedural-incident", suffix
+
+        return TASK_NAME_ALIASES.get(normalized, normalized), None
+
+    @property
+    def last_reset_metadata(self) -> dict[str, Any]:
+        return dict(self._last_reset_metadata)
 
     # ── Public API (called by FastAPI routes) ─────────────────────────────────
 
@@ -108,7 +136,10 @@ class PraxisEnvironment:
         Raises:
             ValueError: if task_name is not registered.
         """
-        canonical_task_name = self.resolve_task_name(task_name)
+        canonical_task_name, procedural_difficulty = self.resolve_task_request(
+            task_name
+        )
+        resolved_seed = seed
 
         self._episode_count += 1
         episode_id = f"{canonical_task_name}_{self._episode_count}"
@@ -118,10 +149,29 @@ class PraxisEnvironment:
             episode_id,
             canonical_task_name,
             task_name,
-            seed,
+            resolved_seed,
         )
 
-        self._scenario = get_scenario(canonical_task_name)
+        if canonical_task_name == "procedural-incident":
+            if resolved_seed is None:
+                resolved_seed = random.randint(0, 2**31 - 1)
+            self._scenario = get_scenario(
+                canonical_task_name,
+                seed=resolved_seed,
+                difficulty=procedural_difficulty,
+            )
+        else:
+            self._scenario = get_scenario(canonical_task_name)
+
+        self._last_reset_metadata = {
+            "seed": resolved_seed,
+            "difficulty": (
+                procedural_difficulty
+                if canonical_task_name == "procedural-incident"
+                else None
+            ),
+            "task_name": canonical_task_name,
+        }
         cutoff = getattr(
             self._scenario,
             "MEMORY_CUTOFF_OVERRIDE",

--- a/server/reward.py
+++ b/server/reward.py
@@ -311,6 +311,10 @@ class RewardEngine:
     def __init__(self, policies: Mapping[str, RewardPolicy] | None = None) -> None:
         self._policies = dict(policies or DEFAULT_REWARD_POLICIES)
 
+    def register_policy(self, task_name: str, policy: RewardPolicy) -> None:
+        """Register or replace a task-level reward policy at runtime."""
+        self._policies[task_name] = policy
+
     def score(
         self,
         *,

--- a/server/session_manager.py
+++ b/server/session_manager.py
@@ -39,6 +39,7 @@ class SessionAllocation:
 
     session: Session
     observation: PraxisObservation
+    metadata: dict[str, int | str | None] = field(default_factory=dict)
 
 
 class SessionManager:
@@ -80,7 +81,11 @@ class SessionManager:
                     evicted_session.task_name,
                 )
             self._sessions[session_id] = session
-        return SessionAllocation(session=session, observation=observation)
+        return SessionAllocation(
+            session=session,
+            observation=observation,
+            metadata=env.last_reset_metadata,
+        )
 
     def get(self, session_id: str) -> Session | None:
         """Return session by id without mutating LRU order."""

--- a/tests/test_task6_procedural.py
+++ b/tests/test_task6_procedural.py
@@ -1,0 +1,99 @@
+"""
+tests/test_task6_procedural.py - Procedural scenario contract tests.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from praxis_env.models import PraxisAction
+from praxis_env.scenarios.procedural_incident import ProceduralIncidentScenario
+from server.app import app
+from server.praxis_environment import PraxisEnvironment
+
+
+client = TestClient(app)
+
+
+@pytest.mark.parametrize(
+    ("difficulty", "expected_steps", "expected_cutoff"),
+    [("easy", 15, 8), ("medium", 25, 15), ("hard", 50, 25)],
+)
+def test_procedural_reset_stamps_difficulty_runtime_config(
+    difficulty, expected_steps, expected_cutoff
+):
+    scenario = ProceduralIncidentScenario(seed=7, difficulty=difficulty)
+    scenario.reset(episode_id="procedural-runtime-config")
+
+    assert scenario.MAX_STEPS == expected_steps
+    assert scenario.MEMORY_CUTOFF_OVERRIDE == expected_cutoff
+    obs = scenario.get_observation()
+    assert obs.alert_summary
+    assert obs.system_status
+
+
+@pytest.mark.parametrize("difficulty", ["easy", "medium", "hard"])
+def test_same_seed_and_difficulty_are_deterministic_for_three_runs(difficulty):
+    commands = [
+        "query_logs",
+        "check_metrics metric=error_rate",
+        "check_config",
+        "diagnose root_cause=definitely_wrong",
+        "rollback_deploy service=api",
+    ]
+
+    def _run_once():
+        env = PraxisEnvironment()
+        initial = env.reset(task_name=f"procedural-incident:{difficulty}", seed=99)
+        trace = [initial.model_dump(mode="json")]
+        for command in commands:
+            result = env.step(PraxisAction(command=command))
+            trace.append(result)
+            if result["done"]:
+                break
+        return trace
+
+    run_1 = _run_once()
+    run_2 = _run_once()
+    run_3 = _run_once()
+    assert run_1 == run_2 == run_3
+
+
+@pytest.mark.parametrize("difficulty", ["easy", "medium", "hard"])
+def test_remediation_before_diagnosis_scores_zero(difficulty):
+    env = PraxisEnvironment()
+    env.reset(task_name=f"procedural-incident:{difficulty}", seed=123)
+
+    result = env.step(PraxisAction(command="rollback_deploy service=api"))
+    assert result["reward"] == pytest.approx(0.01)
+    assert result["done"] is False
+
+
+def test_reset_assigns_default_seed_and_returns_metadata():
+    response = client.post(
+        "/reset", json={"task_name": "procedural-incident", "seed": None}
+    )
+    assert response.status_code == 200
+    metadata = response.json()["metadata"]
+    assert isinstance(metadata["seed"], int)
+    assert metadata["difficulty"] == "medium"
+    assert metadata["task_name"] == "procedural-incident"
+
+
+def test_reset_preserves_explicit_seed_in_metadata():
+    response = client.post(
+        "/reset", json={"task_name": "procedural-incident:hard", "seed": 42}
+    )
+    assert response.status_code == 200
+    metadata = response.json()["metadata"]
+    assert metadata["seed"] == 42
+    assert metadata["difficulty"] == "hard"
+    assert metadata["task_name"] == "procedural-incident"
+
+
+def test_reset_rejects_non_integer_seed():
+    response = client.post(
+        "/reset",
+        json={"task_name": "procedural-incident", "seed": "not-an-int"},
+    )
+    assert response.status_code == 400
+    assert "Invalid seed" in response.json()["detail"]


### PR DESCRIPTION
## Summary
- Fixes #8 by adding `ProceduralIncidentScenario`, a seeded deterministic generator with difficulty tiers (`easy`/`medium`/`hard`) and runtime-stamped `MAX_STEPS` + `MEMORY_CUTOFF_OVERRIDE`.
- Root cause: no procedural scenario implementation existed and no seed/difficulty plumbing was wired from `/reset` through session allocation into scenario construction.
- Added dynamic procedural reward policy registration and explicit diagnosis-before-remediation evidence gating (ADR-13), and returned reset metadata (`seed`, `difficulty`, `task_name`) from `/reset`.
- Updated plan docs to mark procedural scenario/reward sections shipped and cross-linked ADR-07/ADR-13 via ADR-15.

## Test plan
- [x] `python -m pytest tests/test_task6_procedural.py tests/test_api_reset.py tests/test_environment.py tests/test_reward.py`
- [x] `python -m pytest tests/test_scenarios.py`
- [x] Determinism verified for same `(seed, difficulty)` across 3 runs.
- [x] Remediation-before-diagnosis gate verified for `easy`/`medium`/`hard`.

## Assumptions
- `/reset` with missing/null `seed` for procedural flow generates a default integer seed and returns it in response metadata for replay.