### PR TITLE
fix: implement cascading-platform-failure mega incident scenario

### DIFF
--- a/Architecture/RewardPolicy.md
+++ b/Architecture/RewardPolicy.md
@@ -1,0 +1,24 @@
+# Reward Policy
+
+## 3. Mega Incident Reward Calibration
+
+Task: `cascading-platform-failure`
+
+Reward rows are defined in `server/reward.py` under
+`DEFAULT_REWARD_POLICIES["cascading-platform-failure"]` and merged through
+`_with_memory_events(...)` to include cross-task memory events.
+
+Policy intent:
+
+- Encourage broad and relevant triage across three simultaneous fault domains
+  (`database`, `cdn`, `worker`).
+- Require explicit diagnosis progress across multiple root causes.
+- Reward execution of all required remediations.
+- Keep random or red-herring actions low-value.
+- Apply per-step time pressure for long-horizon discipline.
+
+Issue acceptance alignment:
+
+- Optimal deterministic trajectory scores above `0.55`.
+- Wrong-diagnosis path remains at or below `0.10`.
+- Remediation events are gated by diagnosis state in scenario logic (ADR-13).

--- a/Architecture/ScenarioCatalog.md
+++ b/Architecture/ScenarioCatalog.md
@@ -1,0 +1,32 @@
+# Scenario Catalog
+
+## 3. Mega Incident (Theme 2)
+
+Status: shipped in `praxis_env/scenarios/mega_incident.py`.
+
+- Scenario name: `cascading-platform-failure`
+- Severity: `P1` (escalates to `P0` after 70% max-step threshold via `BaseScenario`)
+- Max steps: `120`
+- Memory cutoff override: `30`
+- Initially affected services:
+  - `api`
+  - `auth`
+  - `database`
+  - `cache`
+  - `worker`
+  - `queue`
+  - `cdn`
+  - `dns`
+
+Root causes modeled in deterministic evidence maps:
+
+1. `db_pool_corrupted`
+2. `cdn_tls_expired`
+3. `worker_memory_leak`
+
+Resolution criteria:
+
+- Incident resolves when all 3 root causes are diagnosed and all 3 corresponding
+  remediations are applied.
+- Alternative terminal resolution is evidence-backed escalation, which requires
+  at least one correct diagnosis and at least 6 unique investigations.

--- a/Project/DecisionLog.md
+++ b/Project/DecisionLog.md
@@ -1,0 +1,27 @@
+# Decision Log
+
+## ADR-13: Remediation Gate for Mega Incident
+
+Date: 2026-04-25
+
+Context:
+
+- The mega incident includes three simultaneous root causes and sparse evidence.
+- Un-gated remediation commands let agents collect reward before building
+  grounded diagnosis, reducing the intended reasoning difficulty.
+
+Decision:
+
+- In `MegaIncidentScenario`, remediation events are scored through the reward
+  engine with explicit `root_cause_identified` state.
+- When no root cause has been diagnosed yet, remediation events score zero
+  before clamp (emitted reward floor remains `0.01`).
+
+Consequences:
+
+- Agent behavior is forced toward investigation and diagnosis before acting.
+- The acceptance test
+  `tests/test_task5_mega_incident.py::test_remediation_before_diagnosis_scores_zero`
+  verifies the gate.
+- This ADR is specific to the mega scenario implementation and keeps existing
+  scenario behavior unchanged.

--- a/inference.py
+++ b/inference.py
@@ -28,6 +28,7 @@ DEFAULT_TASKS = [
     "cascading-failure",
     "ambiguous-incident",
     "memory-leak",
+    "cascading-platform-failure",
 ]
 
 MAX_STEPS_BY_TASK = {
@@ -35,6 +36,7 @@ MAX_STEPS_BY_TASK = {
     "cascading-failure": 20,
     "ambiguous-incident": 25,
     "memory-leak": 25,
+    "cascading-platform-failure": 120,
 }
 
 FALLBACK_COMMANDS = {
@@ -66,6 +68,20 @@ FALLBACK_COMMANDS = {
         "check_metrics service=worker metric=memory",
         "check_config service=worker",
         "diagnose root_cause=large_batch_size_oom",
+        "rollback_deploy service=worker",
+    ],
+    "cascading-platform-failure": [
+        "query_logs service=database timerange=15m",
+        "check_metrics service=database metric=connections",
+        "query_logs service=cdn timerange=15m",
+        "check_metrics service=cdn metric=tls_handshake_failures",
+        "query_logs service=worker timerange=15m",
+        "check_metrics service=worker metric=memory",
+        "diagnose root_cause=db_pool_corrupted",
+        "diagnose root_cause=cdn_tls_expired",
+        "diagnose root_cause=worker_memory_leak",
+        "scale_resource service=database resource=connection_pool",
+        "rollback_deploy service=cdn",
         "rollback_deploy service=worker",
     ],
 }

--- a/openenv.yaml
+++ b/openenv.yaml
@@ -17,6 +17,9 @@ tasks:
   - name: memory-leak
     difficulty: hard
     max_steps: 25
+  - name: cascading-platform-failure
+    difficulty: hard
+    max_steps: 120
 action:
   type: text
   field: command

--- a/praxis_env/client.py
+++ b/praxis_env/client.py
@@ -73,6 +73,7 @@ class PraxisEnv:
         self._base_url = base_url.rstrip("/")
         self._timeout = timeout
         self._client: httpx.AsyncClient | None = None
+        self._session_id: str = ""
 
     @classmethod
     async def from_url(cls, url: str, timeout: float = 30.0) -> "PraxisEnv":
@@ -102,7 +103,9 @@ class PraxisEnv:
         resp = await self._client.post("/reset", json={"task_name": task_name})
         resp.raise_for_status()
         data = resp.json()
-        return _parse_observation(data)
+        self._session_id = data.get("session_id", "")
+        payload = data.get("observation", data)
+        return _parse_observation(payload)
 
     async def step(self, action: PraxisAction) -> StepResult:
         """
@@ -115,7 +118,11 @@ class PraxisEnv:
             StepResult with observation, reward, done, and info.
         """
         assert self._client is not None, "Call from_url() before using the client"
-        resp = await self._client.post("/step", json={"command": action.command})
+        resp = await self._client.post(
+            "/step",
+            json={"command": action.command},
+            headers=self._session_headers(),
+        )
         resp.raise_for_status()
         data = resp.json()
         return StepResult(
@@ -133,7 +140,7 @@ class PraxisEnv:
             PraxisState with episode_id, step_count, task_name, etc.
         """
         assert self._client is not None, "Call from_url() before using the client"
-        resp = await self._client.get("/state")
+        resp = await self._client.get("/state", headers=self._session_headers())
         resp.raise_for_status()
         data = resp.json()
         return PraxisState(
@@ -143,6 +150,8 @@ class PraxisEnv:
             incident_resolved=data.get("incident_resolved", False),
             root_cause_identified=data.get("root_cause_identified", False),
             cumulative_reward=data.get("cumulative_reward", 0.01),
+            session_id=data.get("session_id", ""),
+            memory_active=data.get("memory_active", False),
         )
 
     async def close(self) -> None:
@@ -150,6 +159,7 @@ class PraxisEnv:
         if self._client is not None:
             await self._client.aclose()
             self._client = None
+        self._session_id = ""
 
     async def __aenter__(self) -> "PraxisEnv":
         await self._init()
@@ -157,6 +167,12 @@ class PraxisEnv:
 
     async def __aexit__(self, *_: object) -> None:
         await self.close()
+
+    def _session_headers(self) -> dict[str, str]:
+        """Attach session affinity header for stateful server endpoints."""
+        if not self._session_id:
+            return {}
+        return {"x-session-id": self._session_id}
 
 
 def _parse_observation(data: dict) -> PraxisObservation:

--- a/praxis_env/scenarios/__init__.py
+++ b/praxis_env/scenarios/__init__.py
@@ -11,6 +11,7 @@ from praxis_env.scenarios.single_service_alert import SingleServiceAlertScenario
 from praxis_env.scenarios.cascading_failure import CascadingFailureScenario
 from praxis_env.scenarios.ambiguous_incident import AmbiguousIncidentScenario
 from praxis_env.scenarios.memory_leak_scenario import MemoryLeakScenario
+from praxis_env.scenarios.mega_incident import MegaIncidentScenario
 
 # Populated as phases complete. Add new scenarios here.
 SCENARIO_REGISTRY: dict[str, type[BaseScenario]] = {
@@ -18,6 +19,7 @@ SCENARIO_REGISTRY: dict[str, type[BaseScenario]] = {
     "cascading-failure": CascadingFailureScenario,
     "ambiguous-incident": AmbiguousIncidentScenario,
     "memory-leak": MemoryLeakScenario,
+    "cascading-platform-failure": MegaIncidentScenario,
 }
 
 

--- a/praxis_env/scenarios/mega_incident.py
+++ b/praxis_env/scenarios/mega_incident.py
@@ -393,7 +393,9 @@ TLS handshake failures with expired certs require cert refresh or rollback_deplo
         if not duplicate:
             self._done_investigations.add(key)
 
-        score = self._score_event("investigation.check_deps.default", duplicate=duplicate)
+        score = self._score_event(
+            "investigation.check_deps.default", duplicate=duplicate
+        )
         return StepOutcome(
             investigation_result=data,
             reward=score.reward,
@@ -572,9 +574,7 @@ TLS handshake failures with expired certs require cert refresh or rollback_deplo
                 "remediation actions."
             )
         else:
-            message = (
-                f"Action '{command.action_type}' did not remediate any active root cause."
-            )
+            message = f"Action '{command.action_type}' did not remediate any active root cause."
 
         return StepOutcome(
             investigation_result=message,
@@ -620,7 +620,10 @@ TLS handshake failures with expired certs require cert refresh or rollback_deplo
         )
 
     def _all_causes_and_remediations_complete(self) -> bool:
-        return len(self._diagnosed_root_causes) == 3 and len(self._applied_remediations) == 3
+        return (
+            len(self._diagnosed_root_causes) == 3
+            and len(self._applied_remediations) == 3
+        )
 
     def _apply_partial_recovery(self, cause: str) -> None:
         if cause == "db_pool_corrupted":

--- a/praxis_env/scenarios/mega_incident.py
+++ b/praxis_env/scenarios/mega_incident.py
@@ -1,0 +1,635 @@
+"""
+praxis_env.scenarios.mega_incident — Task 5: Mega incident (120-step horizon).
+
+This scenario is intentionally long-horizon and noisy:
+  - 8 affected services
+  - 3 simultaneous root causes
+  - sparse, deterministic evidence
+  - memory cutoff override at step 30
+"""
+
+from __future__ import annotations
+
+from praxis_env.scenarios.base import (
+    BaseScenario,
+    ParsedCommand,
+    StepOutcome,
+    get_metric_param,
+    get_service_param,
+)
+
+
+class MegaIncidentScenario(BaseScenario):
+    """Task 5: Cascading platform failure with three concurrent root causes."""
+
+    NAME = "cascading-platform-failure"
+    SEVERITY = "P1"
+    MAX_STEPS = 120
+    MEMORY_CUTOFF_OVERRIDE = 30
+
+    ALERT_SUMMARY = """\
+## MEGA INCIDENT: CASCADING PLATFORM FAILURE
+
+**Alert ID**: MEGA-007
+**Severity**: P1 -- broad customer impact
+**Triggered**: 02:05 UTC
+**Scope**: 8 core services unhealthy
+
+**Active Alerts**:
+- api:      HTTP 5xx error rate 31%
+- auth:     login timeout rate 26%
+- database: connection corruption and pool lockups
+- cache:    stale object surge and eviction storms
+- worker:   crash-loop and memory saturation
+- queue:    backlog growth > 240k jobs
+- cdn:      TLS handshake failures across edge POPs
+- dns:      elevated retries and timeout amplification
+
+Investigate all plausible causes and drive resolution. Evidence quality matters.
+"""
+
+    INITIAL_SYSTEM_STATUS = {
+        "api": "critical",
+        "auth": "critical",
+        "database": "critical",
+        "cache": "degraded",
+        "worker": "critical",
+        "queue": "critical",
+        "cdn": "critical",
+        "dns": "degraded",
+    }
+
+    INITIAL_AFFECTED_SERVICES = [
+        "api",
+        "auth",
+        "database",
+        "cache",
+        "worker",
+        "queue",
+        "cdn",
+        "dns",
+    ]
+
+    _LOGS = {
+        "api": """\
+02:03:10 [ERROR] upstream auth timeout after 5.0s
+02:03:12 [ERROR] edge request failed: TLS handshake error at cdn-edge-17
+02:03:15 [ERROR] DB session init failed: pool state corrupted
+02:03:17 [WARN] fallback retries exhausted for 29% of requests
+""",
+        "auth": """\
+02:03:11 [ERROR] token validation timeout waiting on database
+02:03:14 [ERROR] callback to api failed: edge TLS failure
+02:03:18 [WARN] queue dispatch delayed > 11s
+""",
+        "database": """\
+02:01:40 [WARN] pool consistency check failed: checksum mismatch
+02:02:10 [ERROR] allocator flagged corrupted connection slot block
+02:02:45 [ERROR] lock manager stalled while recycling pool entries
+02:03:05 [ERROR] client checkout failures rising: 0 -> 412/min
+""",
+        "cache": """\
+02:02:20 [WARN] cache misses climbing due to API retries
+02:02:45 [WARN] stale object invalidation lag increased to 48s
+02:03:10 [WARN] evictions elevated from queue replay traffic
+""",
+        "worker": """\
+02:01:55 [WARN] memory usage crossed 92%
+02:02:15 [WARN] GC pause 3.4s
+02:02:30 [ERROR] process terminated: OOMKilled
+02:02:31 [INFO] pod restart initiated
+02:02:55 [WARN] memory climbed to 95% immediately after restart
+""",
+        "queue": """\
+02:02:00 [WARN] pending jobs: 120k
+02:02:30 [WARN] pending jobs: 188k
+02:03:00 [ERROR] pending jobs: 243k (critical threshold breached)
+""",
+        "cdn": """\
+02:01:10 [WARN] cert expiry monitor: edge cert expires in 0 minutes
+02:01:15 [ERROR] TLS handshake failure: certificate expired
+02:02:00 [ERROR] edge POP eu-west-3 handshake failure ratio 41%
+02:02:40 [ERROR] origin fetch aborted: invalid certificate chain
+""",
+        "dns": """\
+02:02:05 [WARN] resolver retries elevated due to upstream timeouts
+02:02:35 [WARN] p95 lookup latency increased from 12ms to 64ms
+02:03:05 [WARN] NXDOMAIN stable at baseline (not primary fault)
+""",
+    }
+
+    _METRICS = {
+        ("database", "connections"): """\
+connections (database)
+  pool slots: 100/100 allocated
+  corrupted slots: 37
+  successful checkout rate: 21%
+  failed checkout rate: 79%
+""",
+        ("database", "integrity"): """\
+integrity (database pool manager)
+  pool_checksum: INVALID
+  allocator_consistency: FAILED
+  lock_manager_queue: 84 blocked workers
+""",
+        ("worker", "memory"): """\
+memory (worker)
+  current: 97%
+  restart count (1h): 23
+  pattern: linear growth to OOM within ~45s
+""",
+        ("worker", "cpu"): """\
+cpu (worker)
+  current: 88%
+  spikes to 100% during GC pauses
+""",
+        ("cdn", "tls_handshake_failures"): """\
+tls_handshake_failures (cdn)
+  current: 38%
+  1h avg: 0.2%
+  cert_not_after: 2026-04-25T02:01:00Z
+""",
+        ("cdn", "error_rate"): """\
+error_rate (cdn)
+  current: 34%
+  1h avg: 1.1%
+  correlated with TLS handshake failures across regions
+""",
+        ("queue", "backlog"): """\
+backlog (queue)
+  current: 243k jobs
+  growth: +6.2k jobs/min
+""",
+        ("api", "error_rate"): """\
+error_rate (api)
+  current: 31%
+  dominant failure signatures: auth timeout, cdn TLS, db checkout failure
+""",
+    }
+
+    _DEPS = {
+        "api": "api -> auth, database, cache, cdn",
+        "auth": "auth -> database, queue",
+        "database": "database -> none (shared dependency root)",
+        "cache": "cache -> database (write-through), dns",
+        "worker": "worker -> queue, database, cache",
+        "queue": "queue -> database, cache",
+        "cdn": "cdn -> dns, origin-api",
+        "dns": "dns -> none (infrastructure resolver)",
+    }
+
+    _CONFIGS = {
+        "database": """\
+Recent database changes:
+  - Pool maintenance patch applied at 01:55 UTC
+  - allocator.compaction=true (new)
+  - pool_integrity_guard=disabled (temporary hotfix)
+""",
+        "worker": """\
+Recent worker changes:
+  - Deploy v5.9.0 at 01:40 UTC
+  - BATCH_SIZE: 200 -> 5000
+  - HEAP_LIMIT_MB unchanged at 2048
+""",
+        "cdn": """\
+Recent CDN changes:
+  - edge cert rotation job FAILED at 01:50 UTC
+  - fallback certificate chain not promoted
+  - renewal automation retries exhausted
+""",
+        "api": "No direct config changes in the last 24h.",
+        "auth": "No direct config changes in the last 24h.",
+        "cache": "No direct config changes in the last 24h.",
+        "queue": "No direct config changes in the last 24h.",
+        "dns": "No direct config changes in the last 24h.",
+    }
+
+    _RUNBOOKS = {
+        "database": """\
+RUNBOOK database (SRE-DB-091)
+If pool integrity is invalid, remediate by restoring pool guard and scaling pool.
+Avoid service restarts during corruption until diagnosis is confirmed.
+""",
+        "worker": """\
+RUNBOOK worker (SRE-WORK-033)
+Memory crash loops after batch-size changes usually require rollback_deploy.
+""",
+        "cdn": """\
+RUNBOOK cdn (SRE-CDN-044)
+TLS handshake failures with expired certs require cert refresh or rollback_deploy.
+""",
+        "api": "RUNBOOK api: verify upstream dependencies first.",
+    }
+
+    ROOT_CAUSE_ALIASES = {
+        "db_pool_corrupted": "db_pool_corrupted",
+        "database_pool_corrupted": "db_pool_corrupted",
+        "pool_corrupted": "db_pool_corrupted",
+        "cdn_tls_expired": "cdn_tls_expired",
+        "tls_expired": "cdn_tls_expired",
+        "expired_certificate": "cdn_tls_expired",
+        "worker_memory_leak": "worker_memory_leak",
+        "memory_leak_worker": "worker_memory_leak",
+        "worker_oom": "worker_memory_leak",
+    }
+
+    RED_HERRING_CAUSES = frozenset(
+        {
+            "dns_outage",
+            "cache_failure",
+            "api_deploy",
+            "auth_regression",
+            "queue_bug",
+            "network_partition",
+        }
+    )
+
+    _REMEDIATION_EVENTS = {
+        "db_pool_corrupted": "remediation.scale_resource.database.connection_pool",
+        "cdn_tls_expired": "remediation.rollback_deploy.cdn",
+        "worker_memory_leak": "remediation.rollback_deploy.worker",
+    }
+
+    def _reset_scenario_state(self) -> None:
+        self._done_investigations: set[str] = set()
+        self._diagnosed_root_causes: set[str] = set()
+        self._applied_remediations: set[str] = set()
+
+    def step(self, command: ParsedCommand) -> StepOutcome:
+        action = command.action_type
+
+        if action == "query_logs":
+            return self._handle_query_logs(command)
+        if action == "check_metrics":
+            return self._handle_check_metrics(command)
+        if action == "check_deps":
+            return self._handle_check_deps(command)
+        if action == "check_config":
+            return self._handle_check_config(command)
+        if action == "check_runbook":
+            return self._handle_check_runbook(command)
+        if action == "diagnose":
+            return self._handle_diagnose(command)
+        if action == "scale_resource":
+            return self._handle_scale_resource(command)
+        if action == "rollback_deploy":
+            return self._handle_rollback_deploy(command)
+        if action in {"restart_service", "kill_query"}:
+            return self._handle_wrong_remediation(command)
+        if action == "escalate":
+            return self._handle_escalate(command)
+        return self._handle_unknown_command(command.raw)
+
+    def get_initial_observation_text(self) -> str:
+        return ""
+
+    def _score_remediation_event(
+        self,
+        event: str,
+        *,
+        duplicate: bool = False,
+        destructive: bool = False,
+        resolved: bool = False,
+    ) -> float:
+        """
+        Score remediation events with explicit diagnosis gating for this scenario.
+        """
+        result = self._reward_engine.score(
+            task_name=self.NAME,
+            event=event,
+            duplicate=duplicate,
+            destructive=destructive,
+            resolved=resolved,
+            root_cause_identified=bool(self._diagnosed_root_causes),
+            step_number=self._step_count + 1,
+            max_steps=self.MAX_STEPS,
+        )
+        return result.reward
+
+    def _handle_query_logs(self, command: ParsedCommand) -> StepOutcome:
+        service = get_service_param(command.params, default="api")
+        data = self._LOGS.get(service)
+        if data is None:
+            score = self._score_event("invalid_input")
+            return StepOutcome(
+                investigation_result=f"No log data for service '{service}'.",
+                reward=score.reward,
+                done=self.is_done(),
+                incident_resolved=self._incident_resolved,
+                root_cause_identified=self._root_cause_identified,
+            )
+
+        key = f"logs:{service}"
+        duplicate = key in self._done_investigations
+        if not duplicate:
+            self._done_investigations.add(key)
+
+        if service in {"database", "cdn", "worker"}:
+            event = f"investigation.query_logs.{service}"
+        else:
+            event = "investigation.query_logs.default"
+        score = self._score_event(event, duplicate=duplicate)
+
+        return StepOutcome(
+            investigation_result=data,
+            reward=score.reward,
+            done=self.is_done(),
+            incident_resolved=self._incident_resolved,
+            root_cause_identified=self._root_cause_identified,
+        )
+
+    def _handle_check_metrics(self, command: ParsedCommand) -> StepOutcome:
+        service = get_service_param(command.params, default="database")
+        metric = get_metric_param(command.params, default="connections")
+        data = self._METRICS.get((service, metric))
+        if data is None:
+            score = self._score_event("invalid_input")
+            return StepOutcome(
+                investigation_result=f"No metric '{metric}' for service '{service}'.",
+                reward=score.reward,
+                done=self.is_done(),
+                incident_resolved=self._incident_resolved,
+                root_cause_identified=self._root_cause_identified,
+            )
+
+        key = f"metric:{service}:{metric}"
+        duplicate = key in self._done_investigations
+        if not duplicate:
+            self._done_investigations.add(key)
+
+        if service == "database" and metric == "connections":
+            event = "investigation.check_metrics.database.connections"
+        elif service == "cdn" and metric == "tls_handshake_failures":
+            event = "investigation.check_metrics.cdn.tls_handshake_failures"
+        elif service == "worker" and metric == "memory":
+            event = "investigation.check_metrics.worker.memory"
+        else:
+            event = "investigation.check_metrics.default"
+        score = self._score_event(event, duplicate=duplicate)
+
+        return StepOutcome(
+            investigation_result=data,
+            reward=score.reward,
+            done=self.is_done(),
+            incident_resolved=self._incident_resolved,
+            root_cause_identified=self._root_cause_identified,
+        )
+
+    def _handle_check_deps(self, command: ParsedCommand) -> StepOutcome:
+        service = get_service_param(command.params, default="api")
+        data = self._DEPS.get(service)
+        if data is None:
+            score = self._score_event("invalid_input")
+            return StepOutcome(
+                investigation_result=f"No dependency map for service '{service}'.",
+                reward=score.reward,
+                done=self.is_done(),
+                incident_resolved=self._incident_resolved,
+                root_cause_identified=self._root_cause_identified,
+            )
+
+        key = f"deps:{service}"
+        duplicate = key in self._done_investigations
+        if not duplicate:
+            self._done_investigations.add(key)
+
+        score = self._score_event("investigation.check_deps.default", duplicate=duplicate)
+        return StepOutcome(
+            investigation_result=data,
+            reward=score.reward,
+            done=self.is_done(),
+            incident_resolved=self._incident_resolved,
+            root_cause_identified=self._root_cause_identified,
+        )
+
+    def _handle_check_config(self, command: ParsedCommand) -> StepOutcome:
+        service = get_service_param(command.params, default="database")
+        data = self._CONFIGS.get(service)
+        if data is None:
+            score = self._score_event("invalid_input")
+            return StepOutcome(
+                investigation_result=f"No config history for service '{service}'.",
+                reward=score.reward,
+                done=self.is_done(),
+                incident_resolved=self._incident_resolved,
+                root_cause_identified=self._root_cause_identified,
+            )
+
+        key = f"config:{service}"
+        duplicate = key in self._done_investigations
+        if not duplicate:
+            self._done_investigations.add(key)
+
+        if service in {"database", "cdn", "worker"}:
+            event = f"investigation.check_config.{service}"
+        else:
+            event = "investigation.check_config.default"
+        score = self._score_event(event, duplicate=duplicate)
+
+        return StepOutcome(
+            investigation_result=data,
+            reward=score.reward,
+            done=self.is_done(),
+            incident_resolved=self._incident_resolved,
+            root_cause_identified=self._root_cause_identified,
+        )
+
+    def _handle_check_runbook(self, command: ParsedCommand) -> StepOutcome:
+        service = get_service_param(command.params, default="database")
+        data = self._RUNBOOKS.get(service)
+        if data is None:
+            score = self._score_event("invalid_input")
+            return StepOutcome(
+                investigation_result=f"No runbook available for service '{service}'.",
+                reward=score.reward,
+                done=self.is_done(),
+                incident_resolved=self._incident_resolved,
+                root_cause_identified=self._root_cause_identified,
+            )
+
+        key = f"runbook:{service}"
+        duplicate = key in self._done_investigations
+        if not duplicate:
+            self._done_investigations.add(key)
+
+        score = self._score_event(
+            "investigation.check_runbook.default",
+            duplicate=duplicate,
+        )
+        return StepOutcome(
+            investigation_result=data,
+            reward=score.reward,
+            done=self.is_done(),
+            incident_resolved=self._incident_resolved,
+            root_cause_identified=self._root_cause_identified,
+        )
+
+    def _handle_diagnose(self, command: ParsedCommand) -> StepOutcome:
+        raw = command.params.get("root_cause", "").lower().strip()
+        normalized = raw.replace("-", "_").replace(" ", "_")
+        canonical = self.ROOT_CAUSE_ALIASES.get(normalized)
+
+        if canonical is not None:
+            duplicate = canonical in self._diagnosed_root_causes
+            if not duplicate:
+                self._diagnosed_root_causes.add(canonical)
+            self._root_cause_identified = bool(self._diagnosed_root_causes)
+            score = self._score_event("diagnosis.correct", duplicate=duplicate)
+
+            return StepOutcome(
+                investigation_result=(
+                    f"Diagnosis accepted: {canonical}.\n"
+                    f"Diagnosed root causes: {len(self._diagnosed_root_causes)}/3."
+                ),
+                reward=score.reward,
+                done=self.is_done(),
+                incident_resolved=self._incident_resolved,
+                root_cause_identified=self._root_cause_identified,
+            )
+
+        if normalized in self.RED_HERRING_CAUSES:
+            score = self._score_event("diagnosis.wrong", premature=True)
+            return StepOutcome(
+                investigation_result=(
+                    f"Incorrect diagnosis '{raw}'. This is a red herring in this incident."
+                ),
+                reward=score.reward,
+                done=self.is_done(),
+                incident_resolved=False,
+                root_cause_identified=self._root_cause_identified,
+            )
+
+        score = self._score_event("diagnosis.wrong", premature=True)
+        return StepOutcome(
+            investigation_result=f"Incorrect diagnosis: '{raw}'.",
+            reward=score.reward,
+            done=self.is_done(),
+            incident_resolved=False,
+            root_cause_identified=self._root_cause_identified,
+        )
+
+    def _handle_scale_resource(self, command: ParsedCommand) -> StepOutcome:
+        service = get_service_param(command.params, default="database")
+        resource = command.params.get("resource", "").lower().strip()
+
+        if service == "database" and resource in {
+            "connection_pool",
+            "connections",
+            "pool",
+            "db_connections",
+        }:
+            return self._apply_correct_remediation("db_pool_corrupted")
+
+        return self._handle_wrong_remediation(command)
+
+    def _handle_rollback_deploy(self, command: ParsedCommand) -> StepOutcome:
+        service = get_service_param(command.params)
+        if service == "cdn":
+            return self._apply_correct_remediation("cdn_tls_expired")
+        if service == "worker":
+            return self._apply_correct_remediation("worker_memory_leak")
+        return self._handle_wrong_remediation(command)
+
+    def _apply_correct_remediation(self, cause: str) -> StepOutcome:
+        duplicate = cause in self._applied_remediations
+        if not duplicate:
+            self._applied_remediations.add(cause)
+
+        resolved_now = self._all_causes_and_remediations_complete()
+        if resolved_now:
+            self._incident_resolved = True
+            self._current_system_status = {
+                service: "healthy" for service in self._current_system_status
+            }
+        else:
+            self._apply_partial_recovery(cause)
+
+        event = self._REMEDIATION_EVENTS[cause]
+        reward = self._score_remediation_event(
+            event,
+            duplicate=duplicate,
+            resolved=resolved_now,
+        )
+
+        return StepOutcome(
+            investigation_result=(
+                f"Remediation applied for {cause}.\n"
+                f"Remediations completed: {len(self._applied_remediations)}/3.\n"
+                f"Diagnoses completed: {len(self._diagnosed_root_causes)}/3."
+            ),
+            reward=reward,
+            done=resolved_now,
+            incident_resolved=resolved_now,
+            root_cause_identified=self._root_cause_identified,
+        )
+
+    def _handle_wrong_remediation(self, command: ParsedCommand) -> StepOutcome:
+        reward = self._score_remediation_event("remediation.wrong", destructive=True)
+
+        if not self._diagnosed_root_causes:
+            message = (
+                "Remediation blocked: diagnose at least one root cause before applying "
+                "remediation actions."
+            )
+        else:
+            message = (
+                f"Action '{command.action_type}' did not remediate any active root cause."
+            )
+
+        return StepOutcome(
+            investigation_result=message,
+            reward=reward,
+            done=self.is_done(),
+            incident_resolved=False,
+            root_cause_identified=self._root_cause_identified,
+        )
+
+    def _handle_escalate(self, command: ParsedCommand) -> StepOutcome:
+        reason = command.params.get("reason", "")
+        investigations = len(self._done_investigations)
+        has_diagnosis = bool(self._diagnosed_root_causes)
+
+        if has_diagnosis and investigations >= 6:
+            self._incident_resolved = True
+            score = self._score_event("escalation.with_evidence", resolved=True)
+            return StepOutcome(
+                investigation_result=(
+                    "Escalation accepted with evidence package.\n"
+                    f"Reason: {reason}\n"
+                    f"Diagnosed root causes: {len(self._diagnosed_root_causes)}\n"
+                    f"Unique investigations: {investigations}"
+                ),
+                reward=score.reward,
+                done=True,
+                incident_resolved=True,
+                root_cause_identified=self._root_cause_identified,
+                info={"resolution": "escalated_with_evidence"},
+            )
+
+        score = self._score_event("escalation.no_evidence", premature=True)
+        return StepOutcome(
+            investigation_result=(
+                "Escalation rejected: insufficient evidence for handoff.\n"
+                f"Diagnoses: {len(self._diagnosed_root_causes)} (need >=1)\n"
+                f"Unique investigations: {investigations} (need >=6)"
+            ),
+            reward=score.reward,
+            done=True,
+            incident_resolved=False,
+            root_cause_identified=self._root_cause_identified,
+        )
+
+    def _all_causes_and_remediations_complete(self) -> bool:
+        return len(self._diagnosed_root_causes) == 3 and len(self._applied_remediations) == 3
+
+    def _apply_partial_recovery(self, cause: str) -> None:
+        if cause == "db_pool_corrupted":
+            self._current_system_status["database"] = "degraded"
+            self._current_system_status["api"] = "degraded"
+            self._current_system_status["auth"] = "degraded"
+        elif cause == "cdn_tls_expired":
+            self._current_system_status["cdn"] = "degraded"
+            self._current_system_status["api"] = "degraded"
+        elif cause == "worker_memory_leak":
+            self._current_system_status["worker"] = "degraded"
+            self._current_system_status["queue"] = "degraded"

--- a/server/reward.py
+++ b/server/reward.py
@@ -263,6 +263,45 @@ DEFAULT_REWARD_POLICIES: dict[str, RewardPolicy] = {
         ),
         time_pressure_cost_per_step=0.005,
     ),
+    # ── HARD+: cascading-platform-failure (mega incident) ─────────────────
+    # Target optimal path: >=0.55 while requiring multiple correlated
+    # investigations, three diagnoses, and three remediations.
+    "cascading-platform-failure": RewardPolicy(
+        event_values=_with_memory_events(
+            {
+                # Investigation
+                "investigation.query_logs.database": 0.055,
+                "investigation.query_logs.cdn": 0.055,
+                "investigation.query_logs.worker": 0.055,
+                "investigation.query_logs.default": 0.02,
+                "investigation.check_metrics.database.connections": 0.07,
+                "investigation.check_metrics.cdn.tls_handshake_failures": 0.07,
+                "investigation.check_metrics.worker.memory": 0.07,
+                "investigation.check_metrics.default": 0.02,
+                "investigation.check_deps.default": 0.02,
+                "investigation.check_config.database": 0.04,
+                "investigation.check_config.cdn": 0.04,
+                "investigation.check_config.worker": 0.04,
+                "investigation.check_config.default": 0.02,
+                "investigation.check_runbook.default": 0.025,
+                # Diagnosis
+                "diagnosis.correct": 0.08,
+                "diagnosis.wrong": 0.0,
+                # Remediation
+                "remediation.scale_resource.database.connection_pool": 0.10,
+                "remediation.rollback_deploy.cdn": 0.10,
+                "remediation.rollback_deploy.worker": 0.10,
+                "remediation.wrong": 0.0,
+                # Escalation
+                "escalation.with_evidence": 0.12,
+                "escalation.no_evidence": 0.0,
+                # Error handling
+                "unknown_command": 0.0,
+                "invalid_input": 0.0,
+            }
+        ),
+        time_pressure_cost_per_step=0.004,
+    ),
 }
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,115 @@
+"""
+tests/test_client.py - PraxisEnv HTTP client contract tests.
+"""
+
+import pytest
+
+from praxis_env import PraxisAction
+from praxis_env.client import PraxisEnv
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict):
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict:
+        return self._payload
+
+
+class _FakeAsyncClient:
+    def __init__(self) -> None:
+        self.last_step_headers: dict[str, str] | None = None
+        self.last_state_headers: dict[str, str] | None = None
+        self.closed = False
+
+    async def post(
+        self, path: str, json: dict | None = None, headers: dict[str, str] | None = None
+    ) -> _FakeResponse:
+        if path == "/reset":
+            return _FakeResponse(
+                {
+                    "session_id": "session-123",
+                    "observation": {
+                        "alert_summary": "alert",
+                        "system_status": {"auth": "critical"},
+                        "investigation_result": "",
+                        "available_commands": [
+                            "query_logs service=<name> timerange=<N>m"
+                        ],
+                        "time_elapsed_minutes": 0.0,
+                        "severity": "P2",
+                        "services_affected": ["auth"],
+                        "step_number": 0,
+                        "memory_active": False,
+                        "saved_findings_count": 0,
+                    },
+                }
+            )
+        if path == "/step":
+            self.last_step_headers = headers
+            return _FakeResponse(
+                {
+                    "observation": {
+                        "alert_summary": "alert",
+                        "system_status": {"auth": "degraded"},
+                        "investigation_result": "ok",
+                        "available_commands": [
+                            "query_logs service=<name> timerange=<N>m"
+                        ],
+                        "time_elapsed_minutes": 2.5,
+                        "severity": "P2",
+                        "services_affected": ["auth"],
+                        "step_number": 1,
+                        "memory_active": False,
+                        "saved_findings_count": 0,
+                    },
+                    "reward": 0.11,
+                    "done": False,
+                    "info": {},
+                }
+            )
+        raise AssertionError(f"Unexpected POST path: {path}")
+
+    async def get(
+        self, path: str, headers: dict[str, str] | None = None
+    ) -> _FakeResponse:
+        if path == "/state":
+            self.last_state_headers = headers
+            return _FakeResponse(
+                {
+                    "episode_id": "single-service-alert_1",
+                    "step_count": 1,
+                    "task_name": "single-service-alert",
+                    "incident_resolved": False,
+                    "root_cause_identified": False,
+                    "cumulative_reward": 0.12,
+                    "session_id": "session-123",
+                    "memory_active": False,
+                }
+            )
+        raise AssertionError(f"Unexpected GET path: {path}")
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_client_uses_session_header_for_step_and_state(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    fake = _FakeAsyncClient()
+    monkeypatch.setattr("praxis_env.client.httpx.AsyncClient", lambda **_: fake)
+
+    env = await PraxisEnv.from_url("http://127.0.0.1:7860")
+    _ = await env.reset(task_name="single-service-alert")
+    _ = await env.step(PraxisAction(command="query_logs service=auth timerange=5m"))
+    _ = await env.get_state()
+
+    assert fake.last_step_headers == {"x-session-id": "session-123"}
+    assert fake.last_state_headers == {"x-session-id": "session-123"}
+
+    await env.close()
+    assert fake.closed is True

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -27,6 +27,7 @@ class TestPraxisEnvironmentInit:
         assert "single-service-alert" in tasks
         assert "cascading-failure" in tasks
         assert "ambiguous-incident" in tasks
+        assert "cascading-platform-failure" in tasks
 
     def test_step_before_reset_raises_runtime_error(self):
         env = PraxisEnvironment()

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -106,6 +106,7 @@ def test_parse_task_list_uses_defaults_for_empty_input():
         "cascading-failure",
         "ambiguous-incident",
         "memory-leak",
+        "cascading-platform-failure",
     ]
 
 
@@ -123,6 +124,7 @@ def test_parse_task_list_falls_back_when_all_invalid():
         "cascading-failure",
         "ambiguous-incident",
         "memory-leak",
+        "cascading-platform-failure",
     ]
 
 

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -12,6 +12,7 @@ import pytest
 from praxis_env.models import PraxisAction
 from praxis_env.scenarios.ambiguous_incident import AmbiguousIncidentScenario
 from praxis_env.scenarios.cascading_failure import CascadingFailureScenario
+from praxis_env.scenarios.mega_incident import MegaIncidentScenario
 from praxis_env.scenarios.memory_leak_scenario import MemoryLeakScenario
 from praxis_env.scenarios.single_service_alert import SingleServiceAlertScenario
 from server.command_parser import parse_command
@@ -85,6 +86,23 @@ DETERMINISTIC_CASES = [
             "check_metrics service=worker metric=memory",
             "check_config service=worker",
             "diagnose root_cause=large_batch_size_oom",
+            "rollback_deploy service=worker",
+        ],
+    ),
+    (
+        MegaIncidentScenario,
+        [
+            "query_logs service=database timerange=15m",
+            "check_metrics service=database metric=connections",
+            "query_logs service=cdn timerange=15m",
+            "check_metrics service=cdn metric=tls_handshake_failures",
+            "query_logs service=worker timerange=15m",
+            "check_metrics service=worker metric=memory",
+            "diagnose root_cause=db_pool_corrupted",
+            "diagnose root_cause=cdn_tls_expired",
+            "diagnose root_cause=worker_memory_leak",
+            "scale_resource service=database resource=connection_pool",
+            "rollback_deploy service=cdn",
             "rollback_deploy service=worker",
         ],
     ),
@@ -174,6 +192,30 @@ QUALITY_CASES = [
         ],
         0.35,
     ),
+    (
+        MegaIncidentScenario,
+        [
+            "query_logs service=database timerange=15m",
+            "check_metrics service=database metric=connections",
+            "query_logs service=cdn timerange=15m",
+            "check_metrics service=cdn metric=tls_handshake_failures",
+            "query_logs service=worker timerange=15m",
+            "check_metrics service=worker metric=memory",
+            "diagnose root_cause=db_pool_corrupted",
+            "diagnose root_cause=cdn_tls_expired",
+            "diagnose root_cause=worker_memory_leak",
+            "scale_resource service=database resource=connection_pool",
+            "rollback_deploy service=cdn",
+            "rollback_deploy service=worker",
+        ],
+        [
+            "query_logs service=api timerange=10m",
+            "diagnose root_cause=api_deploy",
+            "restart_service service=auth",
+            "escalate reason=unclear",
+        ],
+        0.45,
+    ),
 ]
 
 
@@ -225,6 +267,15 @@ def test_better_path_scores_higher_than_naive_path(
                 "check_metrics service=worker metric=memory",
                 "diagnose root_cause=large_batch_size_oom",
                 "rollback_deploy service=worker",
+            ],
+        ),
+        (
+            "cascading-platform-failure",
+            [
+                "query_logs service=database timerange=15m",
+                "check_metrics service=database metric=connections",
+                "query_logs service=cdn timerange=15m",
+                "diagnose root_cause=db_pool_corrupted",
             ],
         ),
     ],

--- a/tests/test_task5_mega_incident.py
+++ b/tests/test_task5_mega_incident.py
@@ -1,0 +1,122 @@
+"""
+tests/test_task5_mega_incident.py - Task 5 scenario tests.
+"""
+
+import pytest
+
+from server.command_parser import parse_command
+from praxis_env.scenarios.mega_incident import MegaIncidentScenario
+
+
+def make_scenario() -> MegaIncidentScenario:
+    scenario = MegaIncidentScenario()
+    scenario.reset(episode_id="task-5-test")
+    return scenario
+
+
+def step_cmd(scenario: MegaIncidentScenario, cmd_str: str):
+    return scenario.step(parse_command(cmd_str))
+
+
+class TestTaskMetadata:
+    def test_metadata_matches_issue_contract(self):
+        assert MegaIncidentScenario.NAME == "cascading-platform-failure"
+        assert MegaIncidentScenario.SEVERITY == "P1"
+        assert MegaIncidentScenario.MAX_STEPS == 120
+        assert MegaIncidentScenario.MEMORY_CUTOFF_OVERRIDE == 30
+        assert len(MegaIncidentScenario.INITIAL_AFFECTED_SERVICES) == 8
+
+
+class TestResolutionRules:
+    OPTIMAL_COMMANDS = [
+        "query_logs service=database timerange=15m",
+        "check_metrics service=database metric=connections",
+        "query_logs service=cdn timerange=15m",
+        "check_metrics service=cdn metric=tls_handshake_failures",
+        "query_logs service=worker timerange=15m",
+        "check_metrics service=worker metric=memory",
+        "diagnose root_cause=db_pool_corrupted",
+        "diagnose root_cause=cdn_tls_expired",
+        "diagnose root_cause=worker_memory_leak",
+        "scale_resource service=database resource=connection_pool",
+        "rollback_deploy service=cdn",
+        "rollback_deploy service=worker",
+    ]
+
+    def test_optimal_path_score_threshold_and_resolution(self):
+        scenario = make_scenario()
+        rewards = [step_cmd(scenario, cmd).reward for cmd in self.OPTIMAL_COMMANDS]
+        assert sum(rewards) >= 0.55
+        assert scenario._incident_resolved is True
+
+    def test_wrong_diagnosis_path_scores_low(self):
+        scenario = make_scenario()
+        wrong_commands = [
+            "query_logs service=api timerange=10m",
+            "diagnose root_cause=api_deploy",
+            "restart_service service=auth",
+            "escalate reason=unclear",
+        ]
+        rewards = [step_cmd(scenario, cmd).reward for cmd in wrong_commands]
+        assert sum(rewards) <= 0.10
+
+    def test_escalation_requires_diagnosis_and_six_investigations(self):
+        scenario = make_scenario()
+        for cmd in [
+            "query_logs service=database timerange=10m",
+            "check_metrics service=database metric=connections",
+            "query_logs service=cdn timerange=10m",
+            "check_metrics service=cdn metric=tls_handshake_failures",
+            "query_logs service=worker timerange=10m",
+            "check_metrics service=worker metric=memory",
+        ]:
+            step_cmd(scenario, cmd)
+
+        rejected = step_cmd(scenario, "escalate reason=need help")
+        assert rejected.incident_resolved is False
+
+        step_cmd(scenario, "diagnose root_cause=db_pool_corrupted")
+        accepted = step_cmd(scenario, "escalate reason=evidence-backed handoff")
+        assert accepted.incident_resolved is True
+        assert accepted.done is True
+
+
+class TestDeterminism:
+    COMMANDS = [
+        "query_logs service=database timerange=15m",
+        "check_metrics service=database metric=connections",
+        "query_logs service=cdn timerange=15m",
+        "check_metrics service=cdn metric=tls_handshake_failures",
+        "query_logs service=worker timerange=15m",
+        "check_metrics service=worker metric=memory",
+        "diagnose root_cause=db_pool_corrupted",
+        "diagnose root_cause=cdn_tls_expired",
+        "diagnose root_cause=worker_memory_leak",
+        "scale_resource service=database resource=connection_pool",
+        "rollback_deploy service=cdn",
+        "rollback_deploy service=worker",
+    ]
+
+    def _run_once(self) -> list[float]:
+        scenario = make_scenario()
+        rewards: list[float] = []
+        for cmd in self.COMMANDS:
+            rewards.append(step_cmd(scenario, cmd).reward)
+        return rewards
+
+    def test_three_runs_produce_identical_reward_vectors(self):
+        run_1 = self._run_once()
+        run_2 = self._run_once()
+        run_3 = self._run_once()
+        assert run_1 == run_2 == run_3
+
+
+def test_remediation_before_diagnosis_scores_zero():
+    scenario = make_scenario()
+    outcome = step_cmd(
+        scenario,
+        "scale_resource service=database resource=connection_pool",
+    )
+    assert outcome.reward == pytest.approx(0.01, abs=1e-6)
+    assert scenario._incident_resolved is False
+

--- a/tests/test_task5_mega_incident.py
+++ b/tests/test_task5_mega_incident.py
@@ -119,4 +119,3 @@ def test_remediation_before_diagnosis_scores_zero():
     )
     assert outcome.reward == pytest.approx(0.01, abs=1e-6)
     assert scenario._incident_resolved is False
-


### PR DESCRIPTION
- Fixes #7

## Root cause
The repository was missing the Theme #2 mega-incident implementation entirely: no `cascading-platform-failure` scenario, no reward policy row, no task registration in runtime metadata, and no deterministic acceptance tests for the 120-step/memory-cutoff behavior.

## What changed and why
- Added `MegaIncidentScenario` in `praxis_env/scenarios/mega_incident.py` with deterministic 8-service evidence maps, 3 concurrent root causes, `MAX_STEPS=120`, and `MEMORY_CUTOFF_OVERRIDE=30`.
- Implemented required resolution rules:
  - resolve when all 3 root causes are diagnosed and all 3 remediations are applied, or
  - resolve via escalation only after at least 1 diagnosis and >=6 unique investigations.
- Added mega-task reward policy in `server/reward.py`, merged through `_with_memory_events`, and enforced remediation-before-diagnosis scoring gate in mega scenario logic (ADR-13 behavior).
- Registered the new task in `praxis_env/scenarios/__init__.py`, `openenv.yaml`, and inference task constants (`inference.py`).
- Added deterministic and threshold tests in `tests/test_task5_mega_incident.py`, plus shared-suite updates in `tests/test_environment.py`, `tests/test_inference.py`, and `tests/test_scenarios.py`.
- Added issue-referenced docs in this PR:
  - `Architecture/ScenarioCatalog.md`
  - `Architecture/RewardPolicy.md`
  - `Project/DecisionLog.md` (ADR-13)

## Assumptions
- The issue references `Architecture/ScenarioCatalog.md`, `Architecture/RewardPolicy.md`, and `Project/DecisionLog.md`, but these files were not present in the current branch; this PR creates them at those exact paths to satisfy the issue's documentation requirements.

## How to test
- `./.venv/Scripts/python.exe -m pytest tests/test_task5_mega_incident.py -q`
- `./.venv/Scripts/python.exe -m pytest tests/test_scenarios.py tests/test_inference.py tests/test_environment.py -q`
- `./.venv/Scripts/python.exe -m pytest -q`