### PR TITLE
fix: close PR #51 review follow-ups

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -71,18 +71,22 @@ FALLBACK_COMMANDS = {
         "rollback_deploy service=worker",
     ],
     "cascading-platform-failure": [
-        "query_logs service=database timerange=15m",
         "check_metrics service=database metric=connections",
-        "query_logs service=cdn timerange=15m",
         "check_metrics service=cdn metric=tls_handshake_failures",
-        "query_logs service=worker timerange=15m",
         "check_metrics service=worker metric=memory",
+        "check_config service=database",
+        "check_config service=cdn",
+        "check_config service=worker",
         "diagnose root_cause=db_pool_corrupted",
         "diagnose root_cause=cdn_tls_expired",
         "diagnose root_cause=worker_memory_leak",
-        "scale_resource service=database resource=connection_pool",
         "rollback_deploy service=cdn",
+        "scale_resource service=database resource=connection_pool",
         "rollback_deploy service=worker",
+        (
+            "submit_report root_causes=db_pool_corrupted,cdn_tls_expired,"
+            "worker_memory_leak resolution=full_remediation_applied"
+        ),
     ],
 }
 

--- a/praxis_env/client.py
+++ b/praxis_env/client.py
@@ -153,6 +153,11 @@ class PraxisEnv:
             session_id=data.get("session_id", ""),
             memory_active=data.get("memory_active", False),
             final_score=data.get("final_score"),
+            mission_id=data.get("mission_id"),
+            phase=data.get("phase"),
+            plan=data.get("plan", []),
+            checkpoints_completed=data.get("checkpoints_completed", []),
+            artifact_attribution=data.get("artifact_attribution", []),
         )
 
     async def close(self) -> None:
@@ -187,4 +192,8 @@ def _parse_observation(data: dict) -> PraxisObservation:
         severity=data["severity"],
         services_affected=data["services_affected"],
         step_number=int(data["step_number"]),
+        mission_id=data.get("mission_id"),
+        phase=data.get("phase"),
+        time_budget=data.get("time_budget"),
+        pending_objectives=data.get("pending_objectives", []),
     )

--- a/scripts/smoke_concurrency_ratelimit.py
+++ b/scripts/smoke_concurrency_ratelimit.py
@@ -21,8 +21,9 @@ import urllib.error
 import urllib.request
 
 
-def _request(method: str, url: str, *, body: dict | None = None,
-             headers: dict | None = None) -> tuple[int, dict[str, str], Any]:
+def _request(
+    method: str, url: str, *, body: dict | None = None, headers: dict | None = None
+) -> tuple[int, dict[str, str], Any]:
     data = None if body is None else json.dumps(body).encode("utf-8")
     h = {"Content-Type": "application/json"}
     if headers:
@@ -87,19 +88,20 @@ def ratelimit_smoke(base: str) -> None:
         body={"task_name": "single-service-alert", "seed": 7},
     )
     assert status == 200
-    sid = _request("POST", f"{base}/reset",
-                   body={"task_name": "single-service-alert",
-                         "seed": 8})[2]["session_id"]
+    sid = _request(
+        "POST", f"{base}/reset", body={"task_name": "single-service-alert", "seed": 8}
+    )[2]["session_id"]
 
     rl_keys = [
-        k for k in headers
-        if k.lower().startswith("ratelimit")
-        or k.lower().startswith("x-ratelimit")
+        k
+        for k in headers
+        if k.lower().startswith("ratelimit") or k.lower().startswith("x-ratelimit")
     ]
     print(f"[ratelimit] /reset response RateLimit-* headers: {rl_keys}")
     assert rl_keys, "expected slowapi to emit RateLimit-* headers on /reset"
 
     saw_429 = False
+    retry_after: str | None = None
     for i in range(120):
         status, hdr, body = _request(
             "POST",
@@ -109,13 +111,12 @@ def ratelimit_smoke(base: str) -> None:
         )
         if status == 429:
             saw_429 = True
+            retry_after = hdr.get("Retry-After") or hdr.get("retry-after")
             print(f"[ratelimit] hit 429 after {i + 1} bursts: OK")
-            print(f"[ratelimit] retry-after header: "
-                  f"{hdr.get('Retry-After') or hdr.get('retry-after')}")
+            print(f"[ratelimit] retry-after header: {retry_after}")
             break
-    if not saw_429:
-        print("[ratelimit] WARN: did not hit 429 within 120 bursts (limit may "
-              "be configured higher)")
+    assert saw_429, "expected /step burst to eventually return HTTP 429"
+    assert retry_after is not None, "expected 429 response to include Retry-After"
 
 
 async def main() -> int:

--- a/server/app.py
+++ b/server/app.py
@@ -37,6 +37,7 @@ from slowapi.util import get_remote_address
 
 from praxis_env.artifacts import load_default_store
 from praxis_env.models import PraxisAction, PraxisObservation, PraxisState
+from praxis_env.rubrics import default_rubric_bundle
 from praxis_env.scenarios import SCENARIO_REGISTRY
 from server.praxis_environment import PraxisEnvironment
 from server.session_manager import Session, SessionManager
@@ -95,14 +96,32 @@ def _tasks_metadata() -> list[dict[str, Any]]:
     entries: list[dict[str, Any]] = []
     for task_name in task_catalog:
         scenario_cls = SCENARIO_REGISTRY[task_name]
-        entries.append(
-            {
-                "name": task_name,
-                "difficulty": _TASK_DIFFICULTY.get(task_name, "medium"),
-                "max_steps": int(getattr(scenario_cls, "MAX_STEPS", 15)),
-            }
-        )
+        entry: dict[str, Any] = {
+            "name": task_name,
+            "difficulty": _TASK_DIFFICULTY.get(task_name, "medium"),
+            "max_steps": int(getattr(scenario_cls, "MAX_STEPS", 15)),
+        }
+        if task_name == "cascading-platform-failure":
+            entry["phases"] = [
+                "Intake",
+                "Exploration",
+                "Planning",
+                "Execution",
+                "Disturbance",
+                "Recovery",
+                "Completion",
+                "Reflection",
+            ]
+        entries.append(entry)
     return entries
+
+
+def _rubrics_metadata() -> list[dict[str, Any]]:
+    """Return the default rubric bundle advertised by /step info.breakdown."""
+    return [
+        {"name": type(rubric).__name__, "weight": rubric.weight}
+        for rubric in default_rubric_bundle()
+    ]
 
 
 DEFAULT_RATE_LIMIT = os.getenv("PRAXIS_RATE_LIMIT_DEFAULT", "120/minute")
@@ -219,6 +238,7 @@ def create_app() -> FastAPI:
                 "mcp": "/mcp",
             },
             "data_sources": _data_sources_metadata(),
+            "rubrics": _rubrics_metadata(),
         }
 
     @app.get("/schema")
@@ -358,6 +378,11 @@ def create_app() -> FastAPI:
                 "session_id": session_id,
                 "memory_active": s.memory_active,
                 "final_score": s.final_score,
+                "mission_id": s.mission_id,
+                "phase": s.phase,
+                "plan": s.plan,
+                "checkpoints_completed": s.checkpoints_completed,
+                "artifact_attribution": s.artifact_attribution,
             }
         except RuntimeError as e:
             raise HTTPException(status_code=400, detail=str(e))

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -326,3 +326,29 @@ class TestMetadataEndpoint:
 
         assert set(tasks) == set(PraxisEnvironment().list_tasks())
         assert tasks["cascading-platform-failure"]["max_steps"] == 150
+        assert tasks["cascading-platform-failure"]["phases"] == [
+            "Intake",
+            "Exploration",
+            "Planning",
+            "Execution",
+            "Disturbance",
+            "Recovery",
+            "Completion",
+            "Reflection",
+        ]
+
+    def test_metadata_lists_rubrics(self) -> None:
+        from server.app import app
+
+        with TestClient(app) as client:
+            r = client.get("/metadata")
+            assert r.status_code == 200
+            rubrics = r.json()["rubrics"]
+
+        assert {item["name"] for item in rubrics} == {
+            "PlanningRubric",
+            "MemoryRubric",
+            "RecoveryRubric",
+            "TerminalRubric",
+        }
+        assert sum(item["weight"] for item in rubrics) == 1.0

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -45,6 +45,10 @@ class _FakeAsyncClient:
                         "step_number": 0,
                         "memory_active": False,
                         "saved_findings_count": 0,
+                        "mission_id": "mission-123",
+                        "phase": "intake",
+                        "time_budget": 150,
+                        "pending_objectives": ["diagnose root causes"],
                     },
                 }
             )
@@ -65,6 +69,10 @@ class _FakeAsyncClient:
                         "step_number": 1,
                         "memory_active": False,
                         "saved_findings_count": 0,
+                        "mission_id": "mission-123",
+                        "phase": "exploration",
+                        "time_budget": 150,
+                        "pending_objectives": ["diagnose root causes"],
                     },
                     "reward": 0.11,
                     "done": False,
@@ -88,6 +96,12 @@ class _FakeAsyncClient:
                     "cumulative_reward": 0.12,
                     "session_id": "session-123",
                     "memory_active": False,
+                    "final_score": None,
+                    "mission_id": "mission-123",
+                    "phase": "exploration",
+                    "plan": ["triage database"],
+                    "checkpoints_completed": ["intake"],
+                    "artifact_attribution": ["praxis:fixtures"],
                 }
             )
         raise AssertionError(f"Unexpected GET path: {path}")
@@ -104,12 +118,17 @@ async def test_client_uses_session_header_for_step_and_state(
     monkeypatch.setattr("praxis_env.client.httpx.AsyncClient", lambda **_: fake)
 
     env = await PraxisEnv.from_url("http://127.0.0.1:7860")
-    _ = await env.reset(task_name="single-service-alert")
-    _ = await env.step(PraxisAction(command="query_logs service=auth timerange=5m"))
-    _ = await env.get_state()
+    obs = await env.reset(task_name="single-service-alert")
+    step = await env.step(PraxisAction(command="query_logs service=auth timerange=5m"))
+    state = await env.get_state()
 
     assert fake.last_step_headers == {"x-session-id": "session-123"}
     assert fake.last_state_headers == {"x-session-id": "session-123"}
+    assert obs.mission_id == "mission-123"
+    assert step.observation.phase == "exploration"
+    assert state.mission_id == "mission-123"
+    assert state.plan == ["triage database"]
+    assert state.artifact_attribution == ["praxis:fixtures"]
 
     await env.close()
     assert fake.closed is True

--- a/tests/test_final_score_endpoint.py
+++ b/tests/test_final_score_endpoint.py
@@ -42,6 +42,23 @@ def test_state_final_score_is_none_until_episode_done() -> None:
     assert state["final_score"] is None
 
 
+def test_state_endpoint_exposes_mission_metadata() -> None:
+    reset_response = client.post(
+        "/reset", json={"task_name": "cascading-platform-failure", "seed": 42}
+    )
+    assert reset_response.status_code == 200
+    session_id = reset_response.json()["session_id"]
+    headers = {"X-Session-Id": session_id}
+
+    state = client.get("/state", headers=headers).json()
+    assert state["mission_id"] == "mission-0000002a"
+    assert state["phase"] == "intake"
+    assert state["plan"] == []
+    assert state["checkpoints_completed"] == []
+    assert state["artifact_attribution"]
+    assert any("praxis:fixtures" in line for line in state["artifact_attribution"])
+
+
 def test_state_final_score_uses_outcome_times_efficiency() -> None:
     reset_response = client.post("/reset", json={"task_name": "single-service-alert"})
     assert reset_response.status_code == 200

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -132,6 +132,12 @@ def test_mission_inference_budget_matches_scenario_contract():
     assert inference.MAX_STEPS_BY_TASK["cascading-platform-failure"] == 150
 
 
+def test_mission_fallback_sequence_can_reach_submit_report_with_default_cap():
+    commands = inference.FALLBACK_COMMANDS["cascading-platform-failure"]
+    assert len(commands) <= inference.MAX_STEPS_CAP
+    assert commands[-1].startswith("submit_report ")
+
+
 def test_fallback_command_sequences_start_correctly():
     assert (
         inference.fallback_command("single-service-alert", 1)


### PR DESCRIPTION
## Summary

Follow-up to merged PR #51. The owner merged #51 while the final background reviewer findings were still being applied, so this PR carries only the remaining review fixes on top of the now-merged `main`.

## What changed

- `/state` now returns the mission-aware `PraxisState` fields that `PraxisEnvironment.state()` already populated: `mission_id`, `phase`, `plan`, `checkpoints_completed`, and `artifact_attribution`.
- `PraxisEnv` client parsing now preserves mission observation/state fields for HTTP clients.
- `/metadata` now includes the documented `rubrics` list and the mission task phase list.
- `inference.py` mission fallback now reaches `submit_report` within the default `MAX_STEPS_CAP`, so no-token/model-failure mission inference can complete instead of ending at the reward cap before report submission.
- `scripts/smoke_concurrency_ratelimit.py` now fails if it does not observe HTTP 429 plus `Retry-After`, matching the validation claim.

## Validation

- `uv run ruff check praxis_env/ server/ tests/ inference.py scripts/smoke_concurrency_ratelimit.py`
- `uv run ruff format --check praxis_env/ server/ tests/ inference.py scripts/smoke_concurrency_ratelimit.py`
- `uv run pytest -q` -> 487 passed
- `uv run openenv validate`
- `docker build -t praxis-env-mission:dev .`
- Live Docker `/metadata` includes tasks, data_sources, and rubrics
- `scripts/smoke_mission_rollout.py` against Docker -> PASS, `final_score=0.8844`
- `scripts/smoke_concurrency_ratelimit.py` against Docker -> PASS, 429 + Retry-After observed
- No-token `inference.py` mission fallback against Docker -> `success=true`, `score=0.904`
- HF Router `inference.py` smoke against Docker -> START/STEP/END contract executed